### PR TITLE
Scaffold marketplace and implement six language-tool plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,122 @@
+{
+  "name": "yousiki-language-tools",
+  "owner": {
+    "name": "yousiki",
+    "email": "siqi.yang@shanda.com"
+  },
+  "plugins": [
+    {
+      "name": "basedpyright-lsp",
+      "source": "./plugins/basedpyright-lsp",
+      "description": "Basedpyright Python language server (stricter pyright fork). uvx / pipx run fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "lspServers": {
+        "basedpyright": {
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-basedpyright-lsp.sh",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".py": "python",
+            ".pyi": "python"
+          }
+        }
+      }
+    },
+    {
+      "name": "context7",
+      "source": "./plugins/context7",
+      "description": "Upstash Context7 MCP server for up-to-date documentation lookup. bunx / pnpm dlx / npx fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "mcpServers": {
+        "context7": {
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-context7.sh"
+        }
+      }
+    },
+    {
+      "name": "pyright-lsp",
+      "source": "./plugins/pyright-lsp",
+      "description": "Microsoft Pyright Python language server. Routed through the JS/TS chain because pyright is npm-first.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "lspServers": {
+        "pyright": {
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-pyright-lsp.sh",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".py": "python",
+            ".pyi": "python"
+          }
+        }
+      }
+    },
+    {
+      "name": "ruff-formatter",
+      "source": "./plugins/ruff-formatter",
+      "description": "Auto-format Python files with ruff after Claude writes them. PostToolUse hook; uvx / pipx run fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "Write|Edit|MultiEdit",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ruff-format-hook.sh",
+                "timeout": 30
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "ty-lsp",
+      "source": "./plugins/ty-lsp",
+      "description": "Astral ty (Rust-based Python type checker) as an LSP. BETA — pre-1.0, breaking changes ship between patch releases.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "lspServers": {
+        "ty": {
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-ty-lsp.sh",
+          "args": ["server"],
+          "extensionToLanguage": {
+            ".py": "python",
+            ".pyi": "python"
+          }
+        }
+      }
+    },
+    {
+      "name": "typescript-lsp",
+      "source": "./plugins/typescript-lsp",
+      "description": "typescript-language-server for TypeScript / JavaScript. bunx / pnpm dlx / npx fallback, pulls the typescript peer dep fresh.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "lspServers": {
+        "typescript": {
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-typescript-lsp.sh",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".ts": "typescript",
+            ".tsx": "typescriptreact",
+            ".js": "javascript",
+            ".jsx": "javascriptreact",
+            ".mts": "typescript",
+            ".cts": "typescript",
+            ".mjs": "javascript",
+            ".cjs": "javascript"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .worktrees/
+.ruff_cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# yousiki-language-tools
+
+A curated Claude Code plugin marketplace focused on Python / TypeScript language tooling. Every plugin launches its underlying tool through a runtime fallback chain (bunx / pnpm dlx / npx for JS-TS, uvx / pipx run / python -m for Python), so you never need a host-level global install.
+
+Design: see [docs/superpowers/specs/2026-04-17-marketplace-design.md](docs/superpowers/specs/2026-04-17-marketplace-design.md).
+
+## Scope
+
+| Plugin              | Kind   | Runtime chain | Status  |
+| ------------------- | ------ | ------------- | ------- |
+| `context7`          | MCP    | JS/TS         | planned |
+| `typescript-lsp`    | LSP    | JS/TS         | planned |
+| `pyright-lsp`       | LSP    | JS/TS         | planned |
+| `basedpyright-lsp`  | LSP    | Python        | planned |
+| `ty-lsp` (beta)     | LSP    | Python        | planned |
+| `ruff-formatter`    | Hook   | Python        | planned |
+
+## Install
+
+Inside Claude Code:
+
+```
+/plugin marketplace add yousiki/claude-code-plugins
+/plugin install <plugin-name>@yousiki-language-tools
+```
+
+Each plugin's README lists the runtimes it can use; at least one of the chain must be on your `PATH`.
+
+## Repository layout
+
+```
+.
+├── .claude-plugin/marketplace.json   # authoritative plugin list
+├── plugins/<name>/                   # one folder per plugin
+│   ├── .claude-plugin/plugin.json    # metadata only
+│   ├── scripts/launch-<name>.sh      # runtime fallback wrapper
+│   └── README.md
+├── templates/                        # copy-paste references (not executable)
+│   ├── js-ts-tool-plugin/
+│   └── python-tool-plugin/
+└── docs/superpowers/specs/           # design documents
+```
+
+## Contributing a new plugin
+
+1. Decide the runtime chain based on how the tool is distributed (not what it analyzes). See the design doc's "Choose runtime by launcher ecosystem" section.
+2. Copy the matching template into `plugins/<name>/` and fill in the marked sections.
+3. Append a marketplace entry to `.claude-plugin/marketplace.json`.
+4. Test the fallback chain on a machine with only one of the runtimes installed at a time.

--- a/plugins/basedpyright-lsp/.claude-plugin/plugin.json
+++ b/plugins/basedpyright-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "basedpyright-lsp",
+  "version": "0.1.0",
+  "description": "Basedpyright Python language server (community pyright fork with stricter defaults). Launched through uvx / pipx run — no global install required.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/basedpyright-lsp",
+  "license": "MIT"
+}

--- a/plugins/basedpyright-lsp/README.md
+++ b/plugins/basedpyright-lsp/README.md
@@ -1,0 +1,25 @@
+# basedpyright-lsp
+
+[Basedpyright](https://github.com/DetachHead/basedpyright) language server, packaged for Claude Code.
+
+Basedpyright is a community fork of Pyright with stricter defaults and extra diagnostics. Pick this over `pyright-lsp` when you want:
+
+- stricter type narrowing / catch more bugs out of the box
+- `reportUnreachable`, `reportImplicitStringConcatenation`, and similar opt-in-in-pyright rules enabled by default
+- features that haven't yet been upstreamed into Microsoft pyright
+
+You can install both `pyright-lsp` and `basedpyright-lsp`; Claude Code will only run whichever you enable per-project.
+
+## Runtime
+
+Python chain, in order:
+
+1. `uvx --from basedpyright basedpyright-langserver` — preferred
+2. `pipx run --spec basedpyright basedpyright-langserver`
+
+Why `--from` / `--spec`: the PyPI package is `basedpyright` but the language server bin is `basedpyright-langserver`. Without the flag, uvx/pipx would look for a package named `basedpyright-langserver` and fail.
+
+## Notes
+
+- No `python3 -m` fallback: basedpyright doesn't expose a reliable module entry point.
+- Claude Code passes `--stdio` via the marketplace entry's `args` field.

--- a/plugins/basedpyright-lsp/scripts/launch-basedpyright-lsp.sh
+++ b/plugins/basedpyright-lsp/scripts/launch-basedpyright-lsp.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+# Launch basedpyright-langserver with runtime fallback.
+# PyPI package name is `basedpyright`; bin is `basedpyright-langserver`,
+# so uvx/pipx need an explicit "--from"/"--spec" to find the bin.
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+if try uvx; then
+  exec uvx --from basedpyright basedpyright-langserver "$@"
+fi
+if try pipx; then
+  exec pipx run --spec basedpyright basedpyright-langserver "$@"
+fi
+
+cat >&2 <<EOF
+error: no supported Python runtime found on PATH
+tried to launch: basedpyright-langserver (from basedpyright)
+install one of:
+  - https://docs.astral.sh/uv/ (provides uvx)
+  - https://pipx.pypa.io/
+EOF
+exit 127

--- a/plugins/context7/.claude-plugin/plugin.json
+++ b/plugins/context7/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "context7",
+  "version": "0.1.0",
+  "description": "Upstash Context7 MCP server for up-to-date documentation lookup. Marketplace-adapted launcher uses bunx / pnpm dlx / npx fallback so no global install is required.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/context7",
+  "license": "MIT"
+}

--- a/plugins/context7/README.md
+++ b/plugins/context7/README.md
@@ -1,0 +1,30 @@
+# context7
+
+Upstash [Context7](https://github.com/upstash/context7) MCP server for up-to-date documentation lookup. Pulls version-specific docs and code examples into the session.
+
+This is a marketplace-adapted version of Upstash's official `context7` plugin. The upstream plugin hardcodes `npx`; this version uses a runtime fallback wrapper so users with only `bun` or only `pnpm` can run it without installing anything globally.
+
+## Runtime
+
+JS/TS chain, in order:
+
+1. `bunx` — https://bun.sh
+2. `pnpm dlx` — https://pnpm.io
+3. `npx -y` — bundled with Node.js
+
+At least one must be on `PATH`. If none is present, Claude Code will see the MCP server fail to start; the wrapper logs an actionable error to stderr listing each runtime's install URL.
+
+## Files
+
+- `.claude-plugin/plugin.json` — plugin metadata.
+- `scripts/launch-context7.sh` — runtime fallback wrapper, invoked over stdio.
+
+The `mcpServers` block is declared at the marketplace level in the root `.claude-plugin/marketplace.json` entry for this plugin.
+
+## Smoke test
+
+```
+plugins/context7/scripts/launch-context7.sh --help 2>&1 | head -5
+```
+
+Should print Context7's usage banner (or at least not fail with "command not found").

--- a/plugins/context7/scripts/launch-context7.sh
+++ b/plugins/context7/scripts/launch-context7.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+# Launch Upstash Context7 MCP server with runtime fallback.
+set -eu
+
+PKG="@upstash/context7-mcp"
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+if try bunx; then
+  exec bunx "$PKG" "$@"
+fi
+if try pnpm; then
+  exec pnpm dlx "$PKG" -- "$@"
+fi
+if try npx; then
+  exec npx -y "$PKG" -- "$@"
+fi
+
+cat >&2 <<EOF
+error: none of bunx / pnpm / npx found on PATH
+tried to launch: $PKG $*
+install one of:
+  - https://bun.sh
+  - https://pnpm.io
+  - https://nodejs.org (ships npx)
+EOF
+exit 127

--- a/plugins/pyright-lsp/.claude-plugin/plugin.json
+++ b/plugins/pyright-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "pyright-lsp",
+  "version": "0.1.0",
+  "description": "Pyright Python language server. Marketplace-adapted launcher uses bunx / pnpm dlx / npx — pyright is npm-first, so we route through the JS/TS chain regardless of the language analyzed.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/pyright-lsp",
+  "license": "MIT"
+}

--- a/plugins/pyright-lsp/README.md
+++ b/plugins/pyright-lsp/README.md
@@ -1,0 +1,22 @@
+# pyright-lsp
+
+Microsoft [Pyright](https://github.com/microsoft/pyright) language server, packaged for Claude Code with a no-global-install launcher.
+
+## Why the JS/TS chain for a Python tool?
+
+Pyright is distributed primarily on npm; the PyPI `pyright` package is a thin bootstrap that downloads the npm release at runtime. Running it through `bunx` directly is faster and more predictable than going through PyPI. The plugin's runtime chain follows the launcher ecosystem of the tool, not the language it analyzes — see the design doc.
+
+If you want a PyPI-first experience, use `basedpyright-lsp` instead.
+
+## Runtime
+
+JS/TS chain, in order:
+
+1. `bunx -p pyright pyright-langserver`
+2. `pnpm dlx -p pyright pyright-langserver`
+3. `npx -y -p pyright pyright-langserver`
+
+## Notes
+
+- Bin name differs from package name (`pyright` package ships `pyright` and `pyright-langserver` bins); `-p pyright` tells bunx/pnpm/npx which package to install before running the named bin.
+- Claude Code passes `--stdio` via the marketplace entry's `args` field.

--- a/plugins/pyright-lsp/scripts/launch-pyright-lsp.sh
+++ b/plugins/pyright-lsp/scripts/launch-pyright-lsp.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+# Launch pyright-langserver with runtime fallback.
+# The npm package name is `pyright`; the bin we want is `pyright-langserver`,
+# so we use `-p pyright` to widen the install set.
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+if try bunx; then
+  exec bunx -p pyright pyright-langserver "$@"
+fi
+if try pnpm; then
+  exec pnpm dlx -p pyright pyright-langserver -- "$@"
+fi
+if try npx; then
+  exec npx -y -p pyright pyright-langserver -- "$@"
+fi
+
+cat >&2 <<EOF
+error: none of bunx / pnpm / npx found on PATH
+tried to launch: pyright-langserver $*
+install one of:
+  - https://bun.sh
+  - https://pnpm.io
+  - https://nodejs.org (ships npx)
+EOF
+exit 127

--- a/plugins/ruff-formatter/.claude-plugin/plugin.json
+++ b/plugins/ruff-formatter/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "ruff-formatter",
+  "version": "0.1.0",
+  "description": "Auto-format Python files with ruff after Claude writes them. Runs as a PostToolUse hook; uses uvx (preferred) or pipx run to fetch ruff fresh, so no global install is required.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/ruff-formatter",
+  "license": "MIT"
+}

--- a/plugins/ruff-formatter/README.md
+++ b/plugins/ruff-formatter/README.md
@@ -1,0 +1,49 @@
+# ruff-formatter
+
+A PostToolUse hook that runs [`ruff format`](https://docs.astral.sh/ruff/formatter/) on every `.py` / `.pyi` file Claude touches via `Write`, `Edit`, or `MultiEdit`. Never blocks the turn; failures surface as warnings on stderr.
+
+## Runtime
+
+Python chain, in order:
+
+1. `uvx ruff format …` — preferred, isolated
+2. `pipx run ruff format …` — fallback
+
+Install one:
+
+- https://docs.astral.sh/uv/ (provides `uvx`)
+- https://pipx.pypa.io/
+
+If neither is present, the hook logs a one-line skip warning and exits cleanly — the rest of the session continues.
+
+## What it does
+
+- After any `Write | Edit | MultiEdit`, the hook inspects the tool input.
+- If the written file ends in `.py` or `.pyi`, it runs `ruff format <file>` in place.
+- Any other extension exits silently.
+
+## What it does NOT do
+
+- No lint-fix pass (`ruff check --fix`) in this version. Adding it later would let automatic edits change semantics; keep scope tight for v1.
+- No `--check` mode. The hook fires after a write; formatting in place is the point.
+- No configuration passthrough from the project. Ruff picks up `pyproject.toml` / `ruff.toml` as usual via its own discovery rules.
+
+## Files
+
+- `.claude-plugin/plugin.json` — plugin metadata.
+- `scripts/ruff-format-hook.sh` — POSIX sh hook script. Parses stdin JSON, extracts `tool_input.file_path`, runs the runtime fallback chain.
+
+Runtime configuration (the `hooks` block) is declared at the marketplace level in the root `.claude-plugin/marketplace.json` entry for this plugin.
+
+## Smoke testing
+
+On a machine with only `uv` (no pipx, no global ruff):
+
+```
+bash -c 'printf "{\"tool_input\":{\"file_path\":\"/tmp/ruff-smoke.py\"}}\n" > /tmp/ev.json
+         printf "x =  1+2\n" > /tmp/ruff-smoke.py
+         scripts/ruff-format-hook.sh < /tmp/ev.json
+         cat /tmp/ruff-smoke.py'
+```
+
+Expected output: `x = 1 + 2` (reformatted).

--- a/plugins/ruff-formatter/scripts/ruff-format-hook.sh
+++ b/plugins/ruff-formatter/scripts/ruff-format-hook.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+# PostToolUse hook: reformat .py / .pyi files after Write / Edit / MultiEdit.
+# Contract:
+#   - input: Claude Code hook event JSON on stdin.
+#   - output: never blocks the turn. Exits 0 in all paths.
+#     On out-of-scope files, silent. On runtime errors, logs to stderr.
+set -u
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+# Prefer python3 for robust JSON parsing; fall back to a sed/grep pipeline.
+extract_file_path() {
+  if try python3; then
+    python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((d.get("tool_input") or {}).get("file_path") or "")
+' 2>/dev/null
+  else
+    # Flatten newlines and grab the first file_path occurrence.
+    tr '\n' ' ' \
+      | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+      | head -1 \
+      | sed 's/.*"\([^"]*\)"$/\1/'
+  fi
+}
+
+FILE=$(extract_file_path || true)
+
+case "$FILE" in
+  *.py | *.pyi) ;;
+  *) exit 0 ;;
+esac
+
+run_format() {
+  if "$@" format "$FILE"; then
+    return 0
+  fi
+  echo "ruff-formatter: ruff format failed on $FILE" >&2
+}
+
+if try uvx; then
+  run_format uvx ruff
+  exit 0
+fi
+if try pipx; then
+  run_format pipx run ruff
+  exit 0
+fi
+
+echo "ruff-formatter: skipped ($FILE) — install uv (https://docs.astral.sh/uv/) or pipx to enable." >&2
+exit 0

--- a/plugins/ty-lsp/.claude-plugin/plugin.json
+++ b/plugins/ty-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "ty-lsp",
+  "version": "0.1.0",
+  "description": "Astral ty (Rust-based Python type checker) as a language server. BETA: ty is pre-1.0 and breaking changes ship between patch releases — pin versions in the launcher after validating them.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/ty-lsp",
+  "license": "MIT"
+}

--- a/plugins/ty-lsp/README.md
+++ b/plugins/ty-lsp/README.md
@@ -1,0 +1,29 @@
+# ty-lsp
+
+> **BETA.** [ty](https://github.com/astral-sh/ty) is Astral's new Rust-based Python type checker. It is pre-1.0 (`0.0.x`) and breaking changes ship between patch releases. Do not rely on stable behaviour. Pin a tested version in `scripts/launch-ty-lsp.sh` once you have one.
+
+## Runtime
+
+Python chain, in order:
+
+1. `uvx --from ty ty server`
+2. `pipx run --spec ty ty server`
+
+The `server` subcommand starts the LSP. Unlike pyright-family servers, ty does **not** take a `--stdio` flag — stdio is the only / default transport, supplied by the `args: ["server"]` in the marketplace entry.
+
+## Pinning a version
+
+When you find a working `ty` version, edit `scripts/launch-ty-lsp.sh`:
+
+```sh
+PKG="ty==0.0.31"
+```
+
+`uvx --from "ty==X.Y.Z"` and `pipx run --spec "ty==X.Y.Z"` both honour the pin.
+
+## When to pick it
+
+- You want an early look at Astral's next-gen type checker.
+- You accept the instability and are prepared to bump the pin / revert to basedpyright-lsp if a release breaks.
+
+For stable day-to-day type-checking, use `basedpyright-lsp` or `pyright-lsp`.

--- a/plugins/ty-lsp/scripts/launch-ty-lsp.sh
+++ b/plugins/ty-lsp/scripts/launch-ty-lsp.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# Launch ty server (Astral's Rust-based Python type checker LSP) with fallback.
+# BETA: ty is pre-1.0. To pin a tested version, set e.g. PKG="ty==0.0.31".
+set -eu
+
+PKG="ty"   # edit to pin: e.g. "ty==0.0.31"
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+if try uvx; then
+  exec uvx --from "$PKG" ty "$@"
+fi
+if try pipx; then
+  exec pipx run --spec "$PKG" ty "$@"
+fi
+
+cat >&2 <<EOF
+error: no supported Python runtime found on PATH
+tried to launch: ty (from $PKG)
+install one of:
+  - https://docs.astral.sh/uv/ (provides uvx)
+  - https://pipx.pypa.io/
+EOF
+exit 127

--- a/plugins/typescript-lsp/.claude-plugin/plugin.json
+++ b/plugins/typescript-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "typescript-lsp",
+  "version": "0.1.0",
+  "description": "TypeScript / JavaScript language server (typescript-language-server). Marketplace-adapted launcher uses bunx / pnpm dlx / npx fallback and pulls the typescript peer dep fresh — no global install required.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/typescript-lsp",
+  "license": "MIT"
+}

--- a/plugins/typescript-lsp/README.md
+++ b/plugins/typescript-lsp/README.md
@@ -1,0 +1,20 @@
+# typescript-lsp
+
+[`typescript-language-server`](https://github.com/typescript-language-server/typescript-language-server) packaged for Claude Code with a no-global-install launcher.
+
+Upstream's `plugins/typescript-lsp` assumes you've run `npm install -g typescript-language-server typescript`. This version pulls both packages fresh through `bunx` (or `pnpm dlx` / `npx`) on each launch.
+
+## Runtime
+
+JS/TS chain, in order:
+
+1. `bunx -p typescript -p typescript-language-server typescript-language-server`
+2. `pnpm dlx -p typescript -p typescript-language-server typescript-language-server`
+3. `npx -y -p typescript -p typescript-language-server typescript-language-server`
+
+At least one of bun / pnpm / node must be on `PATH`.
+
+## Notes
+
+- The wrapper always pulls a fresh `typescript`. If your project has a specific TypeScript version pinned in `node_modules`, this may diverge. See the design doc's Open Question 5 for the trade-off; revisit if it bites.
+- Language server starts with `--stdio`; Claude Code supplies that via the `args` field in the marketplace entry.

--- a/plugins/typescript-lsp/scripts/launch-typescript-lsp.sh
+++ b/plugins/typescript-lsp/scripts/launch-typescript-lsp.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+# Launch typescript-language-server with runtime fallback.
+# Pulls `typescript` alongside because the language server treats it as a peer
+# dep and upstream's install instructions are "npm install -g … typescript".
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+if try bunx; then
+  exec bunx -p typescript -p typescript-language-server \
+    typescript-language-server "$@"
+fi
+if try pnpm; then
+  exec pnpm dlx -p typescript -p typescript-language-server \
+    typescript-language-server -- "$@"
+fi
+if try npx; then
+  exec npx -y -p typescript -p typescript-language-server \
+    typescript-language-server -- "$@"
+fi
+
+cat >&2 <<EOF
+error: none of bunx / pnpm / npx found on PATH
+tried to launch: typescript-language-server $*
+install one of:
+  - https://bun.sh
+  - https://pnpm.io
+  - https://nodejs.org (ships npx)
+EOF
+exit 127

--- a/templates/js-ts-tool-plugin/README.md
+++ b/templates/js-ts-tool-plugin/README.md
@@ -1,0 +1,28 @@
+# JS/TS Tool Plugin Template
+
+Reference skeleton for plugins that launch an npm-distributed tool. Copy these files into a new `plugins/<name>/` directory and fill in the `<…>` placeholders.
+
+## Files
+
+- `plugin.json.example` → `plugins/<name>/.claude-plugin/plugin.json`
+- `launch.sh.example` → `plugins/<name>/scripts/launch-<name>.sh` (mark executable)
+- `marketplace-entry.example.json` → JSON fragment to paste into the root `.claude-plugin/marketplace.json` under `plugins`
+
+## Runtime chain
+
+The wrapper tries, in order:
+
+1. `bunx` — https://bun.sh
+2. `pnpm dlx` — https://pnpm.io
+3. `npx -y` — bundled with Node.js
+
+If none is available, the wrapper exits 127 with an actionable error listing each runtime's install URL.
+
+## When to use this template
+
+For tools distributed via npm, regardless of what source language they analyze. Examples:
+
+- `typescript-language-server`, `pyright-langserver` (both npm-first)
+- MCP servers published as npm packages (e.g. `@upstash/context7-mcp`)
+
+For PyPI-distributed tools (ruff, basedpyright, ty) use `../python-tool-plugin/` instead.

--- a/templates/js-ts-tool-plugin/launch.sh.example
+++ b/templates/js-ts-tool-plugin/launch.sh.example
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+# JS/TS launcher — copy to plugins/<name>/scripts/launch-<name>.sh and edit PKG.
+# The script is the `command` value in marketplace.json; Claude Code passes
+# additional args (e.g. `--stdio`) through `args` and we forward them with "$@".
+set -eu
+
+PKG="<npm-package>"          # e.g. typescript-language-server, @upstash/context7-mcp
+# Optional extra packages bunx/npx should install alongside PKG (peer deps that
+# the tool expects to find at runtime). Leave empty if not needed.
+PEERS=""                     # e.g. "typescript"
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+# bunx / npx accept multiple `-p <pkg>` flags to widen the install set;
+# pnpm dlx accepts comma-separated packages via `-p`.
+if try bunx; then
+  if [ -n "$PEERS" ]; then
+    # shellcheck disable=SC2086
+    exec bunx $(for p in $PEERS; do printf -- '-p %s ' "$p"; done) "$PKG" "$@"
+  fi
+  exec bunx "$PKG" "$@"
+fi
+if try pnpm; then
+  if [ -n "$PEERS" ]; then
+    exec pnpm dlx -p "$(echo "$PEERS" | tr ' ' ',')" "$PKG" -- "$@"
+  fi
+  exec pnpm dlx "$PKG" -- "$@"
+fi
+if try npx; then
+  if [ -n "$PEERS" ]; then
+    # shellcheck disable=SC2086
+    exec npx -y $(for p in $PEERS; do printf -- '-p %s ' "$p"; done) "$PKG" -- "$@"
+  fi
+  exec npx -y "$PKG" -- "$@"
+fi
+
+cat >&2 <<EOF
+error: none of bunx / pnpm / npx found on PATH
+tried to launch: $PKG $*
+install one of:
+  - https://bun.sh
+  - https://pnpm.io
+  - https://nodejs.org (ships npx)
+EOF
+exit 127

--- a/templates/js-ts-tool-plugin/marketplace-entry.example.json
+++ b/templates/js-ts-tool-plugin/marketplace-entry.example.json
@@ -1,0 +1,26 @@
+{
+  "name": "<plugin-name>",
+  "source": "./plugins/<plugin-name>",
+  "description": "<one-line description>",
+  "version": "0.1.0",
+  "category": "development",
+  "strict": false,
+
+  "// choose ONE of the runtime blocks below": "and delete the others",
+
+  "lspServers": {
+    "<lsp-id>": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-<plugin-name>.sh",
+      "args": ["--stdio"],
+      "extensionToLanguage": {
+        ".ext": "language-id"
+      }
+    }
+  },
+
+  "mcpServers": {
+    "<mcp-id>": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-<plugin-name>.sh"
+    }
+  }
+}

--- a/templates/js-ts-tool-plugin/plugin.json.example
+++ b/templates/js-ts-tool-plugin/plugin.json.example
@@ -1,0 +1,8 @@
+{
+  "name": "<plugin-name>",
+  "version": "0.1.0",
+  "description": "<one-line description>",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/<plugin-name>",
+  "license": "MIT"
+}

--- a/templates/python-tool-plugin/README.md
+++ b/templates/python-tool-plugin/README.md
@@ -1,0 +1,38 @@
+# Python Tool Plugin Template
+
+Reference skeleton for plugins that launch a PyPI-distributed tool. Copy these files into a new `plugins/<name>/` directory and fill in the `<…>` placeholders.
+
+## Files
+
+- `plugin.json.example` → `plugins/<name>/.claude-plugin/plugin.json`
+- `launch.sh.example` → `plugins/<name>/scripts/launch-<name>.sh` (mark executable)
+- `marketplace-entry.example.json` → JSON fragment to paste into the root `.claude-plugin/marketplace.json` under `plugins`
+
+## Runtime chain
+
+The wrapper tries, in order:
+
+1. `uvx` — https://docs.astral.sh/uv/
+2. `pipx run` — https://pipx.pypa.io/
+3. `python -m <module>` — only when the tool exposes a `__main__` entry (set `PY_MODULE`; leave blank to disable)
+
+If none is available, the wrapper exits 127 with an actionable error.
+
+## `--from` handling
+
+When the PyPI package name differs from the console script name (e.g. `basedpyright` package, `basedpyright-langserver` script), `uvx` requires `--from`:
+
+```
+uvx --from basedpyright basedpyright-langserver --stdio
+```
+
+The template wrapper always passes `--from "$PKG"` so this works for both matching and differing names.
+
+## When to use this template
+
+For tools distributed on PyPI, regardless of implementation language. Examples:
+
+- `ruff`, `ty` (Rust implementations, PyPI-distributed)
+- `basedpyright` (Python / TypeScript mix, PyPI recommended)
+
+For npm-distributed tools (pyright, typescript-language-server, npm-packaged MCP servers) use `../js-ts-tool-plugin/` instead.

--- a/templates/python-tool-plugin/launch.sh.example
+++ b/templates/python-tool-plugin/launch.sh.example
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+# Python launcher — copy to plugins/<name>/scripts/launch-<name>.sh and edit
+# PKG / BIN / PY_MODULE. The script is the `command` value in marketplace.json;
+# Claude Code forwards `args` as "$@".
+set -eu
+
+PKG="<pypi-package>"         # e.g. basedpyright, ruff, ty
+BIN="<console-script>"       # e.g. basedpyright-langserver; often equals PKG
+PY_MODULE=""                 # optional: module name for `python3 -m` fallback;
+                             # leave empty when the tool has no `__main__`.
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+# --from works even when PKG == BIN, so it's safe to always pass.
+if try uvx; then
+  exec uvx --from "$PKG" "$BIN" "$@"
+fi
+if try pipx; then
+  exec pipx run --spec "$PKG" "$BIN" "$@"
+fi
+if [ -n "$PY_MODULE" ] && try python3; then
+  exec python3 -m "$PY_MODULE" "$@"
+fi
+
+{
+  echo "error: no supported Python runtime found on PATH"
+  echo "tried to launch: $BIN (from $PKG)"
+  echo "install one of:"
+  echo "  - https://docs.astral.sh/uv/ (provides uvx)"
+  echo "  - https://pipx.pypa.io/"
+  if [ -n "$PY_MODULE" ]; then
+    echo "  - a system python3 (will run: python3 -m $PY_MODULE)"
+  fi
+} >&2
+exit 127

--- a/templates/python-tool-plugin/marketplace-entry.example.json
+++ b/templates/python-tool-plugin/marketplace-entry.example.json
@@ -1,0 +1,36 @@
+{
+  "name": "<plugin-name>",
+  "source": "./plugins/<plugin-name>",
+  "description": "<one-line description>",
+  "version": "0.1.0",
+  "category": "development",
+  "strict": false,
+
+  "// choose ONE of the runtime blocks below": "and delete the others",
+
+  "lspServers": {
+    "<lsp-id>": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-<plugin-name>.sh",
+      "args": ["--stdio"],
+      "extensionToLanguage": {
+        ".py": "python",
+        ".pyi": "python"
+      }
+    }
+  },
+
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-<plugin-name>.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/templates/python-tool-plugin/plugin.json.example
+++ b/templates/python-tool-plugin/plugin.json.example
@@ -1,0 +1,8 @@
+{
+  "name": "<plugin-name>",
+  "version": "0.1.0",
+  "description": "<one-line description>",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/<plugin-name>",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- Adds root `.claude-plugin/marketplace.json` with entries for all six in-scope plugins and a pair of copy-paste templates (`templates/js-ts-tool-plugin/`, `templates/python-tool-plugin/`).
- Implements all six plugins:
  - **context7** (MCP, JS/TS chain)
  - **ruff-formatter** (PostToolUse hook, Python chain)
  - **typescript-lsp**, **pyright-lsp** (LSP, JS/TS chain)
  - **basedpyright-lsp** (LSP, Python chain)
  - **ty-lsp** (LSP, Python chain — marked beta; pre-1.0 upstream)
- Every launcher is a POSIX sh wrapper that walks `bunx` / `pnpm dlx` / `npx` (JS-TS) or `uvx` / `pipx run` (Python), so no host-level global install is required.
- No test harness yet — intentionally deferred as over-engineering for this scope; revisit if the set of plugins grows.

## Test plan
- [ ] Manifest parses: `python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"`
- [ ] Every launcher is valid POSIX sh: `for s in plugins/*/scripts/*.sh; do sh -n "$s" && echo OK "$s"; done`
- [ ] Ruff hook formats a `.py` file: `printf '{"tool_input":{"file_path":"/tmp/t.py"}}' | plugins/ruff-formatter/scripts/ruff-format-hook.sh` (with `uv` or `pipx` on PATH)
- [ ] Ruff hook skips out-of-scope files silently: same invocation with `/tmp/t.md` → exit 0, no output
- [ ] Context7 launches: background-run `plugins/context7/scripts/launch-context7.sh`, expect `Context7 Documentation MCP Server vX.Y.Z running on stdio`
- [ ] Each LSP launcher reaches runtime (10-15s background kill, expect no "command not found"); `ty-lsp` additionally responds to an LSP `initialize` request with a capabilities JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)