### PR TITLE
feat: implement Phase 2 marketplace (17 plugins + template)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -24,6 +24,119 @@
       }
     },
     {
+      "name": "bash-lsp",
+      "source": "./plugins/bash-lsp",
+      "description": "bash-language-server for shell scripts. bunx / pnpm dlx / npx fallback. Integrates with shellcheck when present on PATH.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "lspServers": {
+        "bash": {
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-bash-lsp.sh",
+          "args": ["start"],
+          "extensionToLanguage": {
+            ".sh": "shellscript",
+            ".bash": "shellscript"
+          }
+        }
+      }
+    },
+    {
+      "name": "biome-formatter",
+      "source": "./plugins/biome-formatter",
+      "description": "Auto-format JS / TS / JSON with Biome after Claude writes them. Monolith PostToolUse hook; bunx / pnpm dlx / npx fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "Write|Edit|MultiEdit",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "${CLAUDE_PLUGIN_ROOT}/scripts/biome-format-hook.sh",
+                "timeout": 30
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "biome-js-formatter",
+      "source": "./plugins/biome-js-formatter",
+      "description": "Auto-format JS / TS only with Biome after Claude writes them. PostToolUse hook; bunx / pnpm dlx / npx fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "Write|Edit|MultiEdit",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "${CLAUDE_PLUGIN_ROOT}/scripts/biome-js-format-hook.sh",
+                "timeout": 30
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "biome-json-formatter",
+      "source": "./plugins/biome-json-formatter",
+      "description": "Auto-format JSON / JSONC only with Biome after Claude writes them. PostToolUse hook; bunx / pnpm dlx / npx fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "Write|Edit|MultiEdit",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "${CLAUDE_PLUGIN_ROOT}/scripts/biome-json-format-hook.sh",
+                "timeout": 30
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "biome-lsp",
+      "source": "./plugins/biome-lsp",
+      "description": "Biome language server (lsp-proxy) for JS / TS / JSX / TSX / JSON / JSONC / CSS / GraphQL. bunx / pnpm dlx / npx fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "lspServers": {
+        "biome": {
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-biome-lsp.sh",
+          "args": ["lsp-proxy"],
+          "extensionToLanguage": {
+            ".js": "javascript",
+            ".jsx": "javascriptreact",
+            ".mjs": "javascript",
+            ".cjs": "javascript",
+            ".ts": "typescript",
+            ".tsx": "typescriptreact",
+            ".mts": "typescript",
+            ".cts": "typescript",
+            ".json": "json",
+            ".jsonc": "jsonc",
+            ".css": "css",
+            ".graphql": "graphql",
+            ".gql": "graphql"
+          }
+        }
+      }
+    },
+    {
       "name": "context7",
       "source": "./plugins/context7",
       "description": "Upstash Context7 MCP server for up-to-date documentation lookup. bunx / pnpm dlx / npx fallback.",
@@ -34,6 +147,160 @@
         "context7": {
           "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-context7.sh"
         }
+      }
+    },
+    {
+      "name": "prettier-css-formatter",
+      "source": "./plugins/prettier-css-formatter",
+      "description": "Auto-format CSS / SCSS / Less with Prettier after Claude writes them. PostToolUse hook; bunx / pnpm dlx / npx fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "Write|Edit|MultiEdit",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "${CLAUDE_PLUGIN_ROOT}/scripts/prettier-css-format-hook.sh",
+                "timeout": 30
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "prettier-formatter",
+      "source": "./plugins/prettier-formatter",
+      "description": "Auto-format JS / TS / JSON / CSS / HTML / Markdown / YAML with Prettier after Claude writes them. Monolith PostToolUse hook; bunx / pnpm dlx / npx fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "Write|Edit|MultiEdit",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "${CLAUDE_PLUGIN_ROOT}/scripts/prettier-format-hook.sh",
+                "timeout": 30
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "prettier-html-formatter",
+      "source": "./plugins/prettier-html-formatter",
+      "description": "Auto-format HTML with Prettier after Claude writes them. PostToolUse hook; bunx / pnpm dlx / npx fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "Write|Edit|MultiEdit",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "${CLAUDE_PLUGIN_ROOT}/scripts/prettier-html-format-hook.sh",
+                "timeout": 30
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "prettier-js-formatter",
+      "source": "./plugins/prettier-js-formatter",
+      "description": "Auto-format JS / TS with Prettier after Claude writes them. PostToolUse hook; bunx / pnpm dlx / npx fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "Write|Edit|MultiEdit",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "${CLAUDE_PLUGIN_ROOT}/scripts/prettier-js-format-hook.sh",
+                "timeout": 30
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "prettier-json-formatter",
+      "source": "./plugins/prettier-json-formatter",
+      "description": "Auto-format JSON / JSON5 / JSONC with Prettier after Claude writes them. PostToolUse hook; bunx / pnpm dlx / npx fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "Write|Edit|MultiEdit",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "${CLAUDE_PLUGIN_ROOT}/scripts/prettier-json-format-hook.sh",
+                "timeout": 30
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "prettier-markdown-formatter",
+      "source": "./plugins/prettier-markdown-formatter",
+      "description": "Auto-format Markdown / MDX with Prettier after Claude writes them. PostToolUse hook; bunx / pnpm dlx / npx fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "Write|Edit|MultiEdit",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "${CLAUDE_PLUGIN_ROOT}/scripts/prettier-markdown-format-hook.sh",
+                "timeout": 30
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "prettier-yaml-formatter",
+      "source": "./plugins/prettier-yaml-formatter",
+      "description": "Auto-format YAML with Prettier after Claude writes them. PostToolUse hook; bunx / pnpm dlx / npx fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "hooks": {
+        "PostToolUse": [
+          {
+            "matcher": "Write|Edit|MultiEdit",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "${CLAUDE_PLUGIN_ROOT}/scripts/prettier-yaml-format-hook.sh",
+                "timeout": 30
+              }
+            ]
+          }
+        ]
       }
     },
     {
@@ -77,6 +344,23 @@
       }
     },
     {
+      "name": "tombi-lsp",
+      "source": "./plugins/tombi-lsp",
+      "description": "Tombi TOML language server (schema-aware; Helix uses it by default). uvx / pipx run fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "lspServers": {
+        "tombi": {
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-tombi-lsp.sh",
+          "args": ["lsp"],
+          "extensionToLanguage": {
+            ".toml": "toml"
+          }
+        }
+      }
+    },
+    {
       "name": "ty-lsp",
       "source": "./plugins/ty-lsp",
       "description": "Astral ty (Rust-based Python type checker) as an LSP. BETA — pre-1.0, breaking changes ship between patch releases.",
@@ -114,6 +398,79 @@
             ".cts": "typescript",
             ".mjs": "javascript",
             ".cjs": "javascript"
+          }
+        }
+      }
+    },
+    {
+      "name": "vscode-css-lsp",
+      "source": "./plugins/vscode-css-lsp",
+      "description": "VS Code CSS / SCSS / Less language server (from vscode-langservers-extracted). bunx / pnpm dlx / npx fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "lspServers": {
+        "vscode-css": {
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-vscode-css-lsp.sh",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".css": "css",
+            ".scss": "scss",
+            ".less": "less"
+          }
+        }
+      }
+    },
+    {
+      "name": "vscode-html-lsp",
+      "source": "./plugins/vscode-html-lsp",
+      "description": "VS Code HTML language server (from vscode-langservers-extracted). bunx / pnpm dlx / npx fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "lspServers": {
+        "vscode-html": {
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-vscode-html-lsp.sh",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".html": "html",
+            ".htm": "html"
+          }
+        }
+      }
+    },
+    {
+      "name": "vscode-json-lsp",
+      "source": "./plugins/vscode-json-lsp",
+      "description": "VS Code JSON / JSONC language server (from vscode-langservers-extracted). bunx / pnpm dlx / npx fallback. Overlaps biome-lsp on .json/.jsonc.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "lspServers": {
+        "vscode-json": {
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-vscode-json-lsp.sh",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".json": "json",
+            ".jsonc": "jsonc"
+          }
+        }
+      }
+    },
+    {
+      "name": "yaml-lsp",
+      "source": "./plugins/yaml-lsp",
+      "description": "yaml-language-server with built-in schema catalog (GitHub Actions, Kubernetes, docker-compose). bunx / pnpm dlx / npx fallback.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "lspServers": {
+        "yaml": {
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-yaml-lsp.sh",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".yaml": "yaml",
+            ".yml": "yaml"
           }
         }
       }

--- a/docs/superpowers/specs/2026-04-17-marketplace-phase2-design.md
+++ b/docs/superpowers/specs/2026-04-17-marketplace-phase2-design.md
@@ -1,0 +1,417 @@
+# Marketplace Phase 2 Design — Config/Web LSPs & Per-Language Formatters
+
+Companion to [2026-04-17-marketplace-design.md](2026-04-17-marketplace-design.md). Phase 1 (context7 + Python/TS LSPs + ruff) is in implementation; this document specifies the **second batch** of plugins, to be built only after Phase 1's JS/TS chain launcher and hook contract are proven end-to-end.
+
+This is a full rewrite of the prior Phase 2 draft. Scope and several design decisions changed based on research into Taplo's npm distribution, vscode-langservers-extracted's multi-binary shape, and how Biome/Prettier handle per-file scope.
+
+## Goal
+
+Extend the marketplace to cover:
+
+- **Configuration-file and shell languages** used by JS/TS/Python projects — JSON, HTML, CSS, YAML, TOML, Bash.
+- **Per-language formatter hooks** over the JS/TS/Python file families most projects touch — split into monolith + per-language-subset so users can both one-click-install ("give me everything Biome does") and mix-and-match ("Biome for JSON, Prettier for everything else").
+
+All Phase 2 plugins run through the **existing JS/TS chain** (`bunx` → `pnpm dlx` → `npx`) or **Python chain** (`uvx` → `pipx`) defined in the v2 spec. No new chains; where the shared launcher cannot handle a plugin, it gets a bespoke wrapper on the Phase 1 pyright precedent.
+
+## Relationship to Phase 1
+
+Phase 2 inherits wholesale from the v2 spec:
+
+- JS/TS chain launcher contract (v2 §"JS/TS chain") — used by single-binary npm packages.
+- Python chain launcher contract (v2 §"Python chain") — used by `tombi-lsp`.
+- PostToolUse hook contract (v2 §`ruff-formatter`) — stdin JSON parsing, path extraction, graceful-miss semantics, extension-whitelist early-exit.
+- Manifest split: `marketplace.json` carries runtime (`lspServers` / `hooks`); per-plugin `plugin.json` is metadata only.
+- Failure handling: exit 127 with actionable stderr when no runtime available; exit 0 silently on out-of-scope extensions.
+
+Phase 2 does **not** start until Phase 1 validates the JS/TS launcher on at least one plugin (likely `context7`), the Python launcher on at least one plugin (likely `basedpyright-lsp`), and the hook contract on `ruff-formatter`. If any of those contracts changes during Phase 1 implementation, Phase 2 must be re-reviewed.
+
+## Out of scope (explicit)
+
+- **Nix tooling** — host has no `nix`; defer.
+- **Rust tooling** — rust-analyzer/rustfmt are rustup-coupled and break fresh-exec.
+- **C++/CUDA tooling** — LLVM-coupled; same reason.
+- **Biome experimental languages** — HTML, Vue, Svelte, Astro are opt-in behind `html.experimentalFullSupportEnabled` as of Biome v2.4 and not production-ready.
+- **Prettier plugin ecosystem** — TOML, XML, PHP, shell, Solidity, Java, etc. all require separate `prettier-plugin-*` npm packages whose wrapper shape differs from core. Defer to a future phase.
+- **Niche languages** — Vue, Handlebars, MJML, Angular override, LWC, Flow, GraphQL standalone — low usage; add on-demand later.
+- **Taplo LSP** — `@taplo/cli` npm package does not ship the language server (per Taplo's official docs). Replaced with `tombi-lsp` for TOML coverage.
+
+Revisit any of these if the host gains the relevant toolchain or users specifically ask.
+
+## Full plugin list (17 plugins)
+
+### LSPs (7)
+
+| Plugin | Chain | Package | Binary / subcommand | Languages |
+|---|---|---|---|---|
+| `biome-lsp` | JS/TS | `@biomejs/biome` | `biome lsp-proxy` | JS, TS, JSX, TSX, JSON, JSONC, CSS, GraphQL |
+| `tombi-lsp` | Python | `tombi` (PyPI) | `tombi lsp` | TOML |
+| `yaml-lsp` | JS/TS | `yaml-language-server` | `yaml-language-server --stdio` | YAML |
+| `vscode-html-lsp` | JS/TS (bespoke) | `vscode-langservers-extracted` | `vscode-html-language-server --stdio` | HTML |
+| `vscode-css-lsp` | JS/TS (bespoke) | `vscode-langservers-extracted` | `vscode-css-language-server --stdio` | CSS, SCSS, Less |
+| `vscode-json-lsp` | JS/TS (bespoke) | `vscode-langservers-extracted` | `vscode-json-language-server --stdio` | JSON, JSONC |
+| `bash-lsp` | JS/TS | `bash-language-server` | `bash-language-server start` | Bash, shell |
+
+### Formatters (10)
+
+**Biome family (3)** — covers Biome's most-used stable formatters (JS/TS/JSON). Biome also stably formats CSS and GraphQL, but those are deliberately excluded here as lower-usage; users who need them should use `prettier-css-formatter` / reach for a dedicated GraphQL tool, or request a future subset:
+
+| Plugin | Extension whitelist |
+|---|---|
+| `biome-formatter` (monolith) | `.js .mjs .cjs .jsx .ts .mts .cts .tsx .d.ts .json .jsonc` |
+| `biome-js-formatter` | `.js .mjs .cjs .jsx .ts .mts .cts .tsx .d.ts` |
+| `biome-json-formatter` | `.json .jsonc` |
+
+The monolith whitelist is exactly the union of the subsets — so "install monolith" and "install all subsets" are functionally equivalent (except the parallel-write race makes the latter an error; see §"Formatter coexistence rules").
+
+**Prettier family (7)** — covers Prettier's most-used core formatters:
+
+| Plugin | Extension whitelist |
+|---|---|
+| `prettier-formatter` (monolith) | all of the below unioned |
+| `prettier-js-formatter` | `.js .mjs .cjs .jsx .ts .mts .cts .tsx` |
+| `prettier-json-formatter` | `.json .json5 .jsonc` |
+| `prettier-css-formatter` | `.css .scss .less` |
+| `prettier-html-formatter` | `.html .htm` |
+| `prettier-markdown-formatter` | `.md .markdown .mdx` |
+| `prettier-yaml-formatter` | `.yaml .yml` |
+
+## Design decisions
+
+### Why `tombi-lsp` instead of `taplo-lsp`
+
+The Codex review and a follow-up investigation confirmed: the `@taplo/cli` npm package explicitly does not include the language server. Per Taplo's own docs, `taplo lsp stdio` only exists in the native Rust binary built with `--features lsp`. Options for a Taplo LSP plugin were:
+
+1. `cargo install taplo-cli --features lsp` — requires full Rust toolchain; not fresh-exec friendly.
+2. GitHub releases binary download + plugin-dir cache — viable but requires new platform-detection infrastructure.
+3. **`tombi`** — a Rust TOML LSP distributed as PyPI wheels with a maturin-built binary. Positions itself as a Taplo alternative, is actively maintained, schema-aware, and Helix ships it as the default TOML LSP with `command: "tombi", args: ["lsp"]`.
+
+Option 3 requires zero new infrastructure — it plugs straight into the existing Python chain (`uvx tombi lsp`). Choose tombi now; option 2 can be added later as `taplo-lsp` if a user specifically needs Taplo's features.
+
+### Why `vscode-lsp` is split into three plugins with bespoke wrappers
+
+The `vscode-langservers-extracted` npm package ships three separate binaries:
+
+- `vscode-html-language-server`
+- `vscode-css-language-server`
+- `vscode-json-language-server`
+
+The v2 shared JS/TS launcher does `bunx "$PKG" "$@"` with `$PKG` as the npm package name. This works when **package name equals binary name** (bash, yaml, biome). For multi-binary packages, you must use `bunx -p PACKAGE BIN ...` to disambiguate. Phase 1 already has this precedent: pyright uses `bunx -p pyright pyright-langserver` because its binary name (`pyright-langserver`) differs from the package (`pyright`).
+
+Two design implications:
+
+1. **Three independent plugins, not one plugin with three `lspServers` entries.** This lets users install only the LSPs they want; unused servers aren't spawned. `bunx` caches by package, so all three plugins sharing `vscode-langservers-extracted` only pull the package once locally.
+2. **Each plugin's wrapper is bespoke** — it follows the pyright pattern (`bunx -p vscode-langservers-extracted <binary> "$@"`) and does not delegate to the shared launcher. The fallback chain (bunx → pnpm dlx → npx) is re-expanded in each wrapper.
+
+### Why formatters are split into monolith + per-language subsets
+
+Investigation of Biome and Prettier configuration behavior surfaced three facts:
+
+1. Both tools **default-format** with no project config. There is no `--require-config` flag in either tool, so installing a monolith formatter in a project with no config means every write gets reformatted with defaults.
+2. Both tools support config-driven scope (`files.includes` for Biome, `.prettierignore` for Prettier), but **PostToolUse hooks run in parallel with no ordering guarantee**, so two formatters competing on the same file is a real parallel-write race — not just an idempotence question.
+3. `bunx` caches the underlying npm package; splitting the monolith into multiple per-language plugins does not duplicate installs.
+
+Given those facts, the cleanest design is to **let the plugin boundary itself encode scope** rather than relying on tool config. Each per-language plugin matches only its extensions via the wrapper's whitelist, so two non-overlapping plugins (e.g. `biome-json-formatter` + `prettier-yaml-formatter`) cannot race — their matchers are physically disjoint.
+
+The monolith is offered alongside as a one-click convenience for users whose only answer is "format everything this tool supports" — its whitelist is the union of the subsets.
+
+### Formatter coexistence rules (documented in every formatter README)
+
+Three installation modes are supported:
+
+1. **Install a monolith** (`biome-formatter` or `prettier-formatter`) — everything that tool covers.
+2. **Install one or more per-language subsets** (`biome-js-formatter`, `prettier-yaml-formatter`, etc.) — pick languages.
+3. **Mix across tools** (`biome-js-formatter` + `prettier-yaml-formatter`) — each tool owns its extensions, no overlap.
+
+Unsupported — will cause parallel-write race:
+
+- Monolith **plus** a subset of the same tool (e.g. `biome-formatter` + `biome-json-formatter` both fire on `.json`).
+- Two subsets from different tools claiming the same extension (e.g. `biome-json-formatter` + `prettier-json-formatter`).
+
+The hook wrappers do **not** attempt to detect the race; they just run. README in every formatter plugin calls this out explicitly.
+
+### Why no config-presence gating
+
+An earlier draft considered wrappers that check for `biome.json` / `.prettierrc*` before firing. The research showed the approach works but requires (a) tool-specific flags like `--no-errors-on-unmatched`, (b) walking up to the `.git` root in shell, and (c) users to keep their configs disjoint to avoid the parallel-write race. Net, it pushes complexity into every user's project rather than into our plugin boundaries. The monolith-plus-subsets split achieves the same end (user picks scope) without requiring any project-level configuration.
+
+## LSP specifications
+
+### `biome-lsp`
+
+```json
+{
+  "name": "biome-lsp",
+  "source": "./plugins/biome-lsp",
+  "strict": false,
+  "lspServers": {
+    "biome": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-biome-lsp.sh",
+      "args": ["lsp-proxy"],
+      "extensionToLanguage": {
+        ".js": "javascript", ".jsx": "javascriptreact",
+        ".mjs": "javascript", ".cjs": "javascript",
+        ".ts": "typescript", ".tsx": "typescriptreact",
+        ".mts": "typescript", ".cts": "typescript",
+        ".json": "json", ".jsonc": "jsonc",
+        ".css": "css",
+        ".graphql": "graphql", ".gql": "graphql"
+      }
+    }
+  }
+}
+```
+
+Wrapper: shared JS/TS launcher with `PKG=@biomejs/biome`, `BIN=biome`. Biome's LSP entry point is the subcommand `lsp-proxy`, passed via `args` (not via the wrapper).
+
+**Overlap with `typescript-lsp`**: both register `.ts`/`.tsx`. Claude Code's behavior with overlapping LSPs is an open question — see §"Open questions". Document the overlap in README; instruct users to disable one per-project if double-diagnostics are noisy.
+
+### `tombi-lsp`
+
+```json
+{
+  "name": "tombi-lsp",
+  "source": "./plugins/tombi-lsp",
+  "strict": false,
+  "lspServers": {
+    "tombi": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-tombi-lsp.sh",
+      "args": ["lsp"],
+      "extensionToLanguage": { ".toml": "toml" }
+    }
+  }
+}
+```
+
+Wrapper: **Python chain** launcher with `PKG=tombi`, `BIN=tombi`. The `python -m` fallback branch is skipped (tombi doesn't reliably expose a `-m` entry).
+
+README should note tombi's schema awareness for `pyproject.toml` / `Cargo.toml` and briefly compare to Taplo for users already familiar with the latter.
+
+### `yaml-lsp`
+
+```json
+{
+  "name": "yaml-lsp",
+  "source": "./plugins/yaml-lsp",
+  "strict": false,
+  "lspServers": {
+    "yaml": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-yaml-lsp.sh",
+      "args": ["--stdio"],
+      "extensionToLanguage": { ".yaml": "yaml", ".yml": "yaml" }
+    }
+  }
+}
+```
+
+Wrapper: shared JS/TS launcher with `PKG=yaml-language-server`, `BIN=yaml-language-server`.
+
+README mentions the built-in schema catalog (GitHub Actions, Kubernetes, docker-compose). The server fetches schemas over the network by default — see §"Open questions" for the air-gapped concern.
+
+### `vscode-html-lsp`
+
+```json
+{
+  "name": "vscode-html-lsp",
+  "source": "./plugins/vscode-html-lsp",
+  "strict": false,
+  "lspServers": {
+    "vscode-html": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-vscode-html-lsp.sh",
+      "args": ["--stdio"],
+      "extensionToLanguage": { ".html": "html", ".htm": "html" }
+    }
+  }
+}
+```
+
+Wrapper (`scripts/launch-vscode-html-lsp.sh`), **bespoke**:
+
+```sh
+#!/usr/bin/env sh
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+if try bunx; then
+  exec bunx -p vscode-langservers-extracted vscode-html-language-server "$@"
+fi
+if try pnpm; then
+  exec pnpm --package=vscode-langservers-extracted dlx vscode-html-language-server -- "$@"
+fi
+if try npx; then
+  exec npx -y --package=vscode-langservers-extracted vscode-html-language-server -- "$@"
+fi
+
+echo "error: none of bunx / pnpm / npx found on PATH" >&2
+echo "tried to launch: vscode-html-language-server (from vscode-langservers-extracted)" >&2
+echo "install one of: https://bun.sh  |  https://pnpm.io  |  https://nodejs.org" >&2
+exit 127
+```
+
+### `vscode-css-lsp`
+
+Same shape as `vscode-html-lsp`, with:
+
+- `BIN` → `vscode-css-language-server`
+- `extensionToLanguage` → `{ ".css": "css", ".scss": "scss", ".less": "less" }`
+
+### `vscode-json-lsp`
+
+Same shape as `vscode-html-lsp`, with:
+
+- `BIN` → `vscode-json-language-server`
+- `extensionToLanguage` → `{ ".json": "json", ".jsonc": "jsonc" }`
+
+**Overlap with `biome-lsp`**: both register `.json`/`.jsonc`. Biome contributes lint + formatting diagnostics; vscode-json contributes schema-based completion (tsconfig.json / package.json / composer.json). Document; users can disable one if noisy.
+
+### `bash-lsp`
+
+```json
+{
+  "name": "bash-lsp",
+  "source": "./plugins/bash-lsp",
+  "strict": false,
+  "lspServers": {
+    "bash": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-bash-lsp.sh",
+      "args": ["start"],
+      "extensionToLanguage": { ".sh": "shellscript", ".bash": "shellscript" }
+    }
+  }
+}
+```
+
+Wrapper: shared JS/TS launcher with `PKG=bash-language-server`, `BIN=bash-language-server`. The server integrates `shellcheck` automatically if it's on PATH; we don't install it — README notes that diagnostic quality depends on system `shellcheck`.
+
+## Formatter specifications
+
+### Shared wrapper shape
+
+Every formatter plugin has `scripts/<name>-format-hook.sh` shaped as:
+
+```sh
+#!/usr/bin/env sh
+set -eu
+
+# 1. Parse event JSON from stdin; extract tool_input.file_path.
+FILE=$(python3 -c 'import json,sys;d=json.load(sys.stdin);print(d.get("tool_input",{}).get("file_path",""))')
+[ -n "$FILE" ] || exit 0
+[ -f "$FILE" ] || exit 0
+
+# 2. Extension whitelist (per-plugin: inline list here).
+case "$FILE" in
+  *.js|*.mjs|*.cjs|*.jsx|*.ts|*.mts|*.cts|*.tsx|*.d.ts) ;;   # in-scope
+  *) exit 0 ;;                                                # out-of-scope, silent
+esac
+
+# 3. Run the tool via the JS/TS chain launcher.
+try() { command -v "$1" >/dev/null 2>&1; }
+if try bunx;  then exec bunx @biomejs/biome format --write -- "$FILE"; fi
+if try pnpm;  then exec pnpm dlx @biomejs/biome -- format --write -- "$FILE"; fi
+if try npx;   then exec npx -y  @biomejs/biome format --write -- "$FILE"; fi
+
+# 4. Graceful-miss: no runtime available → warn on stderr, exit 0.
+echo "warning: biome-formatter: no bunx/pnpm/npx on PATH; skipping format of $FILE" >&2
+exit 0
+```
+
+This matches `ruff-formatter` in v2 (graceful-miss semantics; never block Claude's turn on missing runtime). The per-plugin differences are:
+
+- The `case` extension whitelist.
+- The npm package and tool subcommand in the `try` block.
+
+MultiEdit path iteration (v2 Open Question #2): if the `tool_input` exposes multiple file paths under MultiEdit, the extraction line must iterate. **This is a hard dependency on Phase 1's resolution of that question.** Phase 2 wrappers use the resolved contract directly; if Phase 1 lands with `file_path` as the only field, Phase 2 inherits that limitation until the upstream contract improves.
+
+### Formatter matchers (marketplace fragment)
+
+All formatters use the same `matcher` and differ only in `command`. Example for `biome-json-formatter`:
+
+```json
+{
+  "name": "biome-json-formatter",
+  "source": "./plugins/biome-json-formatter",
+  "strict": false,
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          { "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/biome-json-format-hook.sh",
+            "timeout": 15 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The remaining 9 formatter plugins (`biome-formatter`, `biome-js-formatter`, `prettier-formatter`, `prettier-js-formatter`, `prettier-json-formatter`, `prettier-css-formatter`, `prettier-html-formatter`, `prettier-markdown-formatter`, `prettier-yaml-formatter`) each have the same fragment shape with the `name`, `source`, and `command` path adjusted. The only substantive differences are **the extension whitelist** and **the tool command** inside the script:
+
+| Plugin | Extension whitelist (`case` patterns) | Tool command |
+|---|---|---|
+| `biome-formatter` | `*.js\|*.mjs\|*.cjs\|*.jsx\|*.ts\|*.mts\|*.cts\|*.tsx\|*.d.ts\|*.json\|*.jsonc` | `@biomejs/biome format --write -- "$FILE"` |
+| `biome-js-formatter` | `*.js\|*.mjs\|*.cjs\|*.jsx\|*.ts\|*.mts\|*.cts\|*.tsx\|*.d.ts` | same |
+| `biome-json-formatter` | `*.json\|*.jsonc` | same |
+| `prettier-formatter` | union of all prettier per-language whitelists below | `prettier --write -- "$FILE"` |
+| `prettier-js-formatter` | `*.js\|*.mjs\|*.cjs\|*.jsx\|*.ts\|*.mts\|*.cts\|*.tsx` | same |
+| `prettier-json-formatter` | `*.json\|*.json5\|*.jsonc` | same |
+| `prettier-css-formatter` | `*.css\|*.scss\|*.less` | same |
+| `prettier-html-formatter` | `*.html\|*.htm` | same |
+| `prettier-markdown-formatter` | `*.md\|*.markdown\|*.mdx` | same |
+| `prettier-yaml-formatter` | `*.yaml\|*.yml` | same |
+
+## Templates
+
+Add one new template to `templates/`:
+
+- `templates/formatter-hook-plugin/` — reference skeleton for a PostToolUse formatter plugin. Mirrors the existing `ruff-formatter` shape. Contains:
+  - `README.md` — "when to use, how to fill in the blanks"
+  - `.claude-plugin/plugin.json.example` — metadata skeleton
+  - `scripts/format-hook.sh.example` — the script above with `# EDIT ME` markers for the `case` whitelist and the tool command
+  - `marketplace-entry.example.json` — fragment to paste into root `marketplace.json`
+
+No new LSP template needed — the existing `js-ts-tool-plugin` and `python-tool-plugin` already cover all seven Phase 2 LSP plugins. (`vscode-*-lsp` uses the `js-ts-tool-plugin` template plus a bespoke-wrapper note in its README.)
+
+## Rollout order
+
+Ordered by implementation risk and incremental pattern coverage. Each step gates on the prior passing v2's smoke matrix (one runtime at a time: `bun`, `pnpm`, `npm`, `uv`, `pipx`, none).
+
+1. **`bash-lsp`** — simplest single-server LSP, zero special cases. Fastest second-use of the JS/TS launcher.
+2. **`yaml-lsp`** — same pattern. Pair with bash-lsp in one PR.
+3. **`tombi-lsp`** — first second-use of the Python launcher outside Phase 1. Proves the chain transfers cleanly.
+4. **`vscode-html-lsp`** — first bespoke wrapper in Phase 2. Prove the multi-binary `bunx -p` pattern on one server before replicating.
+5. **`vscode-css-lsp` + `vscode-json-lsp`** — copy the html plugin with binary name changed.
+6. **`biome-lsp`** — monolith LSP; exercises overlap-with-typescript-lsp story.
+7. **`biome-formatter`** + **`prettier-formatter`** — monolith formatters. Pair in one PR so overlap documentation is written once.
+8. **Per-language formatter subsets** — 2 biome + 6 prettier = 8 plugins. Each is a copy of its monolith with a narrower `case` whitelist. Land as one or two PRs.
+
+## Verification
+
+Per v2 §"Verification", manual in this phase. Each plugin README carries its own check:
+
+- **LSPs**: open a file with a matching extension, confirm diagnostics / hover.
+- **`vscode-*-lsp`**: verify each of the three plugins starts its intended binary; install two together, confirm both servers spawn.
+- **Monolith formatter**: ask Claude to write a deliberately-misformatted file with an in-scope extension; verify on-disk result is reformatted.
+- **Subset formatter**: verify it reformats in-scope extensions **and** leaves out-of-scope extensions untouched.
+- **Coexistence sanity**:
+  - `biome-js-formatter` + `prettier-yaml-formatter` installed together: write `.ts` → only biome fires; write `.yaml` → only prettier fires. No race.
+  - `biome-formatter` + `biome-json-formatter` installed together (the unsupported case): write `.json` → both fire; document that on-disk corruption is possible and tell the user to uninstall one.
+
+CI automation remains out of scope.
+
+## Failure handling
+
+All Phase 2 plugins inherit v2's failure-handling contract unchanged:
+
+- LSPs: exit 127 with actionable stderr when no runtime is available.
+- Formatters: exit 0 silently on out-of-scope file extensions; exit 0 with a warning on stderr when the runtime is missing; exit non-zero only when the tool itself failed.
+
+## Open questions
+
+Resolve during implementation; do not block the rollout.
+
+1. **Overlapping LSP dispatch** — what does Claude Code do when two LSPs register the same extension (`biome-lsp` + `typescript-lsp` on `.ts`, `biome-lsp` + `vscode-json-lsp` on `.json`)? Three possibilities: both spawn and contribute diagnostics, first-registered wins, last-registered wins. Verify during `biome-lsp` implementation. If "first wins," the per-project disable instructions in the READMEs must be more prominent.
+2. **Prettier config discovery** — prettier reads project config (`.prettierrc*`, `package.json`) from cwd. Confirm that running via `bunx` with cwd at the Claude Code launch directory still discovers project config correctly.
+3. **Biome config discovery** — same question for `biome.json` / `biome.jsonc`.
+4. **yaml-language-server schema fetch** — the server fetches remote schemas by default. In air-gapped environments this may hang or fail. Document; if it bites, add an opt-out env var (candidate: `YAML_LS_DISABLE_SCHEMA_DOWNLOAD`).
+5. **MultiEdit file-path iteration** — inherited from v2 Open Question #2. Phase 2 wrappers use whatever contract Phase 1 lands with.

--- a/plugins/bash-lsp/.claude-plugin/plugin.json
+++ b/plugins/bash-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "bash-lsp",
+  "version": "0.1.0",
+  "description": "Bash language server, launched via bunx / pnpm dlx / npx fallback without requiring a global install.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/bash-lsp",
+  "license": "MIT"
+}

--- a/plugins/bash-lsp/README.md
+++ b/plugins/bash-lsp/README.md
@@ -1,0 +1,36 @@
+# bash-lsp
+
+[`bash-language-server`](https://github.com/bash-lsp/bash-language-server) packaged for Claude Code with a no-global-install launcher.
+
+## What it is
+
+`bash-lsp` provides language-server features for shell scripts, including diagnostics, completion, hover, and document symbols where the upstream server supports them.
+
+Use it when a project contains shell entrypoints, maintenance scripts, install scripts, or CI helper scripts that Claude Code should understand as shell code.
+
+## How it runs
+
+JS/TS chain, in order:
+
+1. `bunx bash-language-server`
+2. `pnpm dlx bash-language-server`
+3. `npx -y bash-language-server`
+
+At least one of bun / pnpm / node must be on `PATH`.
+
+Claude Code passes the language-server startup arguments via the marketplace entry. The wrapper only selects the first available runtime and execs `bash-language-server` with those arguments.
+
+## Extensions
+
+This plugin registers:
+
+- `.sh`
+- `.bash`
+
+Runtime configuration (the `lspServers` block) is declared at the marketplace level in the root `.claude-plugin/marketplace.json` entry for this plugin.
+
+## Notes
+
+- `bash-language-server` integrates with `shellcheck` when `shellcheck` is already installed and visible on `PATH`.
+- This plugin does not install `shellcheck`; diagnostic quality depends on the tools available on the host system.
+- If none of bunx, pnpm, or npx are available, the launcher exits 127 and prints install URLs for the supported runtimes.

--- a/plugins/bash-lsp/scripts/launch-bash-lsp.sh
+++ b/plugins/bash-lsp/scripts/launch-bash-lsp.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+if try bunx; then
+  exec bunx bash-language-server "$@"
+fi
+if try pnpm; then
+  exec pnpm dlx bash-language-server -- "$@"
+fi
+if try npx; then
+  exec npx -y bash-language-server -- "$@"
+fi
+
+cat >&2 <<EOF
+error: none of bunx / pnpm / npx found on PATH
+tried to launch: bash-language-server $*
+install one of:
+  - https://bun.sh
+  - https://pnpm.io
+  - https://nodejs.org
+EOF
+exit 127

--- a/plugins/biome-formatter/.claude-plugin/plugin.json
+++ b/plugins/biome-formatter/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "biome-formatter",
+  "version": "0.1.0",
+  "description": "Format JS, TS, JSON, and JSONC files on save using Biome via bunx/pnpm/npx.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/biome-formatter",
+  "license": "MIT"
+}

--- a/plugins/biome-formatter/README.md
+++ b/plugins/biome-formatter/README.md
@@ -1,0 +1,51 @@
+# biome-formatter
+
+A PostToolUse hook that runs [`biome format --write`](https://biomejs.dev/formatter/) on every supported JavaScript, TypeScript, JSON, or JSONC file Claude touches via `Write`, `Edit`, or `MultiEdit`. Never blocks the turn when the runtime is missing; missing-runtime cases surface as warnings on stderr.
+
+## Runtime
+
+JS/TS chain, in order:
+
+1. `bunx -p @biomejs/biome biome format --write …` — preferred, isolated
+2. `pnpm --package=@biomejs/biome dlx biome -- format --write …` — fallback
+3. `npx -y --package=@biomejs/biome biome format --write …` — fallback
+
+Install one:
+
+- https://bun.sh
+- https://pnpm.io
+- https://nodejs.org/ (ships `npx`)
+
+If none is present, the hook logs a one-line skip warning and exits cleanly; the rest of the session continues.
+
+## What it does
+
+- After any `Write | Edit | MultiEdit`, the hook inspects the tool input.
+- If the written file ends in `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.mts`, `.cts`, `.tsx`, `.d.ts`, `.json`, or `.jsonc`, it runs Biome format in place.
+- Any other extension exits silently.
+
+## Coexistence
+
+Supported installation modes:
+
+- `biome-formatter` alone, as the monolith for all Biome-owned JS, TS, JSON, and JSONC files.
+- Subset formatters alone, such as `biome-js-formatter` or `biome-json-formatter`, when you want narrower Biome ownership.
+- Cross-tool subsets with disjoint extensions, such as `biome-js-formatter` plus `ruff-formatter`.
+
+Unsupported modes:
+
+- `biome-formatter` plus a same-tool subset such as `biome-js-formatter` or `biome-json-formatter`.
+- Two formatter subsets that both claim the same extension.
+
+Those unsupported combinations can race because PostToolUse hooks may run in parallel. The hook does not try to detect that race.
+
+## Files
+
+- `.claude-plugin/plugin.json` — plugin metadata.
+- `scripts/biome-format-hook.sh` — POSIX sh hook script. Parses stdin JSON, extracts `tool_input.file_path`, runs the runtime fallback chain.
+
+Runtime configuration (the `hooks` block) is declared at the marketplace level in the root `.claude-plugin/marketplace.json` entry for this plugin.
+
+## Smoke testing
+
+Write a deliberately misformatted `.ts` or `.jsonc` file through Claude, then verify the on-disk file is rewritten by Biome.

--- a/plugins/biome-formatter/scripts/biome-format-hook.sh
+++ b/plugins/biome-formatter/scripts/biome-format-hook.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+# PostToolUse hook: reformat JS, TS, JSON, and JSONC files after Write / Edit / MultiEdit.
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+# Prefer python3 for robust JSON parsing; fall back to a sed/grep pipeline.
+extract_file_path() {
+  if try python3; then
+    python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((d.get("tool_input") or {}).get("file_path") or "")
+' 2>/dev/null
+  else
+    # Flatten newlines and grab the first file_path occurrence.
+    tr '\n' ' ' \
+      | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+      | head -1 \
+      | sed 's/.*"\([^"]*\)"$/\1/'
+  fi
+}
+
+FILE=$(extract_file_path || true)
+[ -f "$FILE" ] || exit 0
+
+case "$FILE" in
+  *.js | *.mjs | *.cjs | *.jsx | *.ts | *.mts | *.cts | *.tsx | *.d.ts | *.json | *.jsonc) ;;
+  *) exit 0 ;;
+esac
+
+if try bunx; then
+  exec bunx -p @biomejs/biome biome format --write -- "$FILE"
+fi
+if try pnpm; then
+  exec pnpm --package=@biomejs/biome dlx biome -- format --write -- "$FILE"
+fi
+if try npx; then
+  exec npx -y --package=@biomejs/biome biome format --write -- "$FILE"
+fi
+
+echo "biome-formatter: skipped ($FILE) - install bun, pnpm, or Node.js/npm to enable." >&2
+exit 0

--- a/plugins/biome-js-formatter/.claude-plugin/plugin.json
+++ b/plugins/biome-js-formatter/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "biome-js-formatter",
+  "version": "0.1.0",
+  "description": "Format JS and TS files on save using Biome via bunx/pnpm/npx.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/biome-js-formatter",
+  "license": "MIT"
+}

--- a/plugins/biome-js-formatter/README.md
+++ b/plugins/biome-js-formatter/README.md
@@ -1,0 +1,51 @@
+# biome-js-formatter
+
+A PostToolUse hook that runs [`biome format --write`](https://biomejs.dev/formatter/) on every supported JavaScript or TypeScript file Claude touches via `Write`, `Edit`, or `MultiEdit`. Never blocks the turn when the runtime is missing; missing-runtime cases surface as warnings on stderr.
+
+## Runtime
+
+JS/TS chain, in order:
+
+1. `bunx -p @biomejs/biome biome format --write …` — preferred, isolated
+2. `pnpm --package=@biomejs/biome dlx biome -- format --write …` — fallback
+3. `npx -y --package=@biomejs/biome biome format --write …` — fallback
+
+Install one:
+
+- https://bun.sh
+- https://pnpm.io
+- https://nodejs.org/ (ships `npx`)
+
+If none is present, the hook logs a one-line skip warning and exits cleanly; the rest of the session continues.
+
+## What it does
+
+- After any `Write | Edit | MultiEdit`, the hook inspects the tool input.
+- If the written file ends in `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.mts`, `.cts`, `.tsx`, or `.d.ts`, it runs Biome format in place.
+- Any other extension exits silently.
+
+## Coexistence
+
+Supported installation modes:
+
+- `biome-js-formatter` alone, when Biome should own only JavaScript and TypeScript files.
+- `biome-js-formatter` plus `biome-json-formatter`, since their extension whitelists do not overlap.
+- Cross-tool subsets with disjoint extensions, such as `biome-js-formatter` plus `ruff-formatter`.
+
+Unsupported modes:
+
+- `biome-js-formatter` plus `biome-formatter`, because the monolith already owns the same JS and TS extensions.
+- Any other formatter subset that claims the same JS or TS extensions.
+
+Those unsupported combinations can race because PostToolUse hooks may run in parallel. The hook does not try to detect that race.
+
+## Files
+
+- `.claude-plugin/plugin.json` — plugin metadata.
+- `scripts/biome-js-format-hook.sh` — POSIX sh hook script. Parses stdin JSON, extracts `tool_input.file_path`, runs the runtime fallback chain.
+
+Runtime configuration (the `hooks` block) is declared at the marketplace level in the root `.claude-plugin/marketplace.json` entry for this plugin.
+
+## Smoke testing
+
+Write a deliberately misformatted `.ts` or `.tsx` file through Claude, then verify the on-disk file is rewritten by Biome.

--- a/plugins/biome-js-formatter/scripts/biome-js-format-hook.sh
+++ b/plugins/biome-js-formatter/scripts/biome-js-format-hook.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+# PostToolUse hook: reformat JS and TS files after Write / Edit / MultiEdit.
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+# Prefer python3 for robust JSON parsing; fall back to a sed/grep pipeline.
+extract_file_path() {
+  if try python3; then
+    python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((d.get("tool_input") or {}).get("file_path") or "")
+' 2>/dev/null
+  else
+    # Flatten newlines and grab the first file_path occurrence.
+    tr '\n' ' ' \
+      | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+      | head -1 \
+      | sed 's/.*"\([^"]*\)"$/\1/'
+  fi
+}
+
+FILE=$(extract_file_path || true)
+[ -f "$FILE" ] || exit 0
+
+case "$FILE" in
+  *.js | *.mjs | *.cjs | *.jsx | *.ts | *.mts | *.cts | *.tsx | *.d.ts) ;;
+  *) exit 0 ;;
+esac
+
+if try bunx; then
+  exec bunx -p @biomejs/biome biome format --write -- "$FILE"
+fi
+if try pnpm; then
+  exec pnpm --package=@biomejs/biome dlx biome -- format --write -- "$FILE"
+fi
+if try npx; then
+  exec npx -y --package=@biomejs/biome biome format --write -- "$FILE"
+fi
+
+echo "biome-js-formatter: skipped ($FILE) - install bun, pnpm, or Node.js/npm to enable." >&2
+exit 0

--- a/plugins/biome-json-formatter/.claude-plugin/plugin.json
+++ b/plugins/biome-json-formatter/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "biome-json-formatter",
+  "version": "0.1.0",
+  "description": "Format JSON and JSONC files on save using Biome via bunx/pnpm/npx.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/biome-json-formatter",
+  "license": "MIT"
+}

--- a/plugins/biome-json-formatter/README.md
+++ b/plugins/biome-json-formatter/README.md
@@ -1,0 +1,51 @@
+# biome-json-formatter
+
+A PostToolUse hook that runs [`biome format --write`](https://biomejs.dev/formatter/) on every JSON or JSONC file Claude touches via `Write`, `Edit`, or `MultiEdit`. Never blocks the turn when the runtime is missing; missing-runtime cases surface as warnings on stderr.
+
+## Runtime
+
+JS/TS chain, in order:
+
+1. `bunx -p @biomejs/biome biome format --write …` — preferred, isolated
+2. `pnpm --package=@biomejs/biome dlx biome -- format --write …` — fallback
+3. `npx -y --package=@biomejs/biome biome format --write …` — fallback
+
+Install one:
+
+- https://bun.sh
+- https://pnpm.io
+- https://nodejs.org/ (ships `npx`)
+
+If none is present, the hook logs a one-line skip warning and exits cleanly; the rest of the session continues.
+
+## What it does
+
+- After any `Write | Edit | MultiEdit`, the hook inspects the tool input.
+- If the written file ends in `.json` or `.jsonc`, it runs Biome format in place.
+- Any other extension exits silently.
+
+## Coexistence
+
+Supported installation modes:
+
+- `biome-json-formatter` alone, when Biome should own only JSON and JSONC files.
+- `biome-json-formatter` plus `biome-js-formatter`, since their extension whitelists do not overlap.
+- Cross-tool subsets with disjoint extensions, such as `biome-json-formatter` plus `ruff-formatter`.
+
+Unsupported modes:
+
+- `biome-json-formatter` plus `biome-formatter`, because the monolith already owns the same JSON and JSONC extensions.
+- Any other formatter subset that claims `.json` or `.jsonc`.
+
+Those unsupported combinations can race because PostToolUse hooks may run in parallel. The hook does not try to detect that race.
+
+## Files
+
+- `.claude-plugin/plugin.json` — plugin metadata.
+- `scripts/biome-json-format-hook.sh` — POSIX sh hook script. Parses stdin JSON, extracts `tool_input.file_path`, runs the runtime fallback chain.
+
+Runtime configuration (the `hooks` block) is declared at the marketplace level in the root `.claude-plugin/marketplace.json` entry for this plugin.
+
+## Smoke testing
+
+Write a deliberately misformatted `.jsonc` file through Claude, then verify the on-disk file is rewritten by Biome.

--- a/plugins/biome-json-formatter/scripts/biome-json-format-hook.sh
+++ b/plugins/biome-json-formatter/scripts/biome-json-format-hook.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+# PostToolUse hook: reformat JSON and JSONC files after Write / Edit / MultiEdit.
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+# Prefer python3 for robust JSON parsing; fall back to a sed/grep pipeline.
+extract_file_path() {
+  if try python3; then
+    python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((d.get("tool_input") or {}).get("file_path") or "")
+' 2>/dev/null
+  else
+    # Flatten newlines and grab the first file_path occurrence.
+    tr '\n' ' ' \
+      | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+      | head -1 \
+      | sed 's/.*"\([^"]*\)"$/\1/'
+  fi
+}
+
+FILE=$(extract_file_path || true)
+[ -f "$FILE" ] || exit 0
+
+case "$FILE" in
+  *.json | *.jsonc) ;;
+  *) exit 0 ;;
+esac
+
+if try bunx; then
+  exec bunx -p @biomejs/biome biome format --write -- "$FILE"
+fi
+if try pnpm; then
+  exec pnpm --package=@biomejs/biome dlx biome -- format --write -- "$FILE"
+fi
+if try npx; then
+  exec npx -y --package=@biomejs/biome biome format --write -- "$FILE"
+fi
+
+echo "biome-json-formatter: skipped ($FILE) - install bun, pnpm, or Node.js/npm to enable." >&2
+exit 0

--- a/plugins/biome-lsp/.claude-plugin/plugin.json
+++ b/plugins/biome-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "biome-lsp",
+  "version": "0.1.0",
+  "description": "Biome language server, launched via bunx / pnpm dlx / npx fallback without requiring a global install.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/biome-lsp",
+  "license": "MIT"
+}

--- a/plugins/biome-lsp/README.md
+++ b/plugins/biome-lsp/README.md
@@ -24,11 +24,11 @@ Claude Code passes the language-server startup arguments via the marketplace ent
 
 This plugin registers:
 
-- `.js`
-- `.ts`
-- `.tsx`
-- `.jsx`
-- `.json`
+- JS family: `.js`, `.mjs`, `.cjs`, `.jsx`
+- TS family: `.ts`, `.tsx`, `.mts`, `.cts`
+- JSON family: `.json`, `.jsonc`
+- CSS: `.css`
+- GraphQL: `.graphql`, `.gql`
 
 Runtime configuration (the `lspServers` block) is declared at the marketplace level in the root `.claude-plugin/marketplace.json` entry for this plugin.
 

--- a/plugins/biome-lsp/README.md
+++ b/plugins/biome-lsp/README.md
@@ -1,0 +1,39 @@
+# biome-lsp
+
+[`@biomejs/biome`](https://biomejs.dev/) language server, packaged for Claude Code with a no-global-install launcher.
+
+## What it is
+
+`biome-lsp` provides Biome's language-server features for JavaScript, TypeScript, JSX, TSX, and JSON files where the upstream server supports them.
+
+Use it when you want Biome diagnostics and editor intelligence available inside Claude Code without requiring a project-local or global Biome install.
+
+## How it runs
+
+JS/TS chain, in order:
+
+1. `bunx -p @biomejs/biome biome`
+2. `pnpm --package=@biomejs/biome dlx biome`
+3. `npx -y --package=@biomejs/biome biome`
+
+At least one of bun / pnpm / node must be on `PATH`.
+
+Claude Code passes the language-server startup arguments via the marketplace entry. The wrapper only selects the first available runtime and execs `biome` with those arguments.
+
+## Extensions
+
+This plugin registers:
+
+- `.js`
+- `.ts`
+- `.tsx`
+- `.jsx`
+- `.json`
+
+Runtime configuration (the `lspServers` block) is declared at the marketplace level in the root `.claude-plugin/marketplace.json` entry for this plugin.
+
+## Notes
+
+- `biome-lsp` overlaps with `typescript-lsp` for `.ts` and `.tsx` files.
+- If both are enabled in the same project and diagnostics become noisy, disable one of the two per project.
+- If none of bunx, pnpm, or npx are available, the launcher exits 127 and prints install URLs for the supported runtimes.

--- a/plugins/biome-lsp/scripts/launch-biome-lsp.sh
+++ b/plugins/biome-lsp/scripts/launch-biome-lsp.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+if try bunx; then
+  exec bunx -p @biomejs/biome biome "$@"
+fi
+if try pnpm; then
+  exec pnpm --package=@biomejs/biome dlx biome -- "$@"
+fi
+if try npx; then
+  exec npx -y --package=@biomejs/biome biome -- "$@"
+fi
+
+cat >&2 <<EOF
+error: none of bunx / pnpm / npx found on PATH
+tried to launch: biome (from @biomejs/biome) $*
+install one of:
+  - https://bun.sh
+  - https://pnpm.io
+  - https://nodejs.org
+EOF
+exit 127

--- a/plugins/prettier-css-formatter/.claude-plugin/plugin.json
+++ b/plugins/prettier-css-formatter/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "prettier-css-formatter",
+  "version": "0.1.0",
+  "description": "Auto-format CSS, SCSS, and Less files with Prettier after Claude writes them via a PostToolUse hook.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/prettier-css-formatter",
+  "license": "MIT"
+}

--- a/plugins/prettier-css-formatter/README.md
+++ b/plugins/prettier-css-formatter/README.md
@@ -1,0 +1,55 @@
+# prettier-css-formatter
+
+A PostToolUse hook that runs Prettier on CSS, SCSS, and Less files Claude touches via `Write`, `Edit`, or `MultiEdit`.
+
+## Runtime
+
+JavaScript chain, in order:
+
+1. `bunx prettier --write -- <file>` - preferred
+2. `pnpm dlx prettier -- --write -- <file>` - fallback
+3. `npx -y prettier --write -- <file>` - fallback
+
+Install one:
+
+- https://bun.sh
+- https://pnpm.io
+- https://nodejs.org
+
+If none is present, the hook logs a one-line skip warning and exits cleanly.
+
+## What it does
+
+- After any `Write | Edit | MultiEdit`, the hook inspects the tool input.
+- If the written file ends in `.css`, `.scss`, or `.less`, it runs `prettier --write -- <file>` in place.
+- Any other extension exits silently.
+- Prettier discovers project configuration and ignore files through its normal rules.
+
+## Coexistence
+
+Supported:
+
+- `prettier-css-formatter` alone, or with other non-overlapping Prettier subsets.
+- Subset plugins alone when you want selected languages without installing `prettier-formatter`.
+- Cross-tool subsets with disjoint extensions, such as `biome-json-formatter` + `prettier-yaml-formatter`.
+
+Unsupported:
+
+- `prettier-formatter` plus `prettier-css-formatter`, because both hooks can write CSS-family files.
+- Two formatter subsets covering the same extension.
+
+The hook does not detect these races; uninstall one overlapping formatter instead.
+
+## Files
+
+- `.claude-plugin/plugin.json` - plugin metadata.
+- `scripts/prettier-css-format-hook.sh` - POSIX sh hook script that parses stdin JSON and formats matching files.
+- `README.md` - usage notes and coexistence rules.
+
+Runtime configuration (the `hooks` block) belongs in the root `.claude-plugin/marketplace.json` entry.
+
+## Smoke testing
+
+Feed a hook event containing a matching `tool_input.file_path` into `scripts/prettier-css-format-hook.sh`.
+The file should be rewritten by Prettier when one runtime is installed.
+Out-of-scope files should produce no output and exit 0.

--- a/plugins/prettier-css-formatter/scripts/prettier-css-format-hook.sh
+++ b/plugins/prettier-css-formatter/scripts/prettier-css-format-hook.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+# PostToolUse hook: reformat CSS-family files after Write / Edit / MultiEdit.
+# Contract:
+#   - input: Claude Code hook event JSON on stdin.
+#   - output: never blocks the turn. Exits 0 in all paths.
+#     On out-of-scope files, silent. On missing runtimes, logs to stderr.
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+# Prefer python3 for robust JSON parsing; fall back to a sed/grep pipeline.
+extract_file_path() {
+  if try python3; then
+    python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((d.get("tool_input") or {}).get("file_path") or "")
+' 2>/dev/null
+  else
+    # Flatten newlines and grab the first file_path occurrence.
+    tr '\n' ' ' \
+      | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+      | head -1 \
+      | sed 's/.*"\([^"]*\)"$/\1/'
+  fi
+}
+
+FILE=$(extract_file_path || true)
+
+case "$FILE" in
+  *.css | *.scss | *.less) ;;
+  *) exit 0 ;;
+esac
+
+if try bunx; then exec bunx prettier --write -- "$FILE"; fi
+if try pnpm; then exec pnpm dlx prettier -- --write -- "$FILE"; fi
+if try npx;  then exec npx -y prettier --write -- "$FILE"; fi
+
+echo "prettier-css-formatter: skipped ($FILE) — install bun (https://bun.sh), pnpm (https://pnpm.io), or Node.js (ships npx) to enable." >&2
+exit 0

--- a/plugins/prettier-css-formatter/scripts/prettier-css-format-hook.sh
+++ b/plugins/prettier-css-formatter/scripts/prettier-css-format-hook.sh
@@ -29,6 +29,8 @@ print((d.get("tool_input") or {}).get("file_path") or "")
 }
 
 FILE=$(extract_file_path || true)
+[ -n "$FILE" ] || exit 0
+[ -f "$FILE" ] || exit 0
 
 case "$FILE" in
   *.css | *.scss | *.less) ;;

--- a/plugins/prettier-formatter/.claude-plugin/plugin.json
+++ b/plugins/prettier-formatter/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "prettier-formatter",
+  "version": "0.1.0",
+  "description": "Auto-format JavaScript, TypeScript, JSON, CSS, HTML, Markdown, MDX, and YAML files with Prettier after Claude writes them via a PostToolUse hook.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/prettier-formatter",
+  "license": "MIT"
+}

--- a/plugins/prettier-formatter/README.md
+++ b/plugins/prettier-formatter/README.md
@@ -1,0 +1,55 @@
+# prettier-formatter
+
+A PostToolUse hook that runs Prettier on common JS, TS, JSON, CSS, HTML, Markdown, MDX, and YAML files Claude touches via `Write`, `Edit`, or `MultiEdit`.
+
+## Runtime
+
+JavaScript chain, in order:
+
+1. `bunx prettier --write -- <file>` - preferred
+2. `pnpm dlx prettier -- --write -- <file>` - fallback
+3. `npx -y prettier --write -- <file>` - fallback
+
+Install one:
+
+- https://bun.sh
+- https://pnpm.io
+- https://nodejs.org
+
+If none is present, the hook logs a one-line skip warning and exits cleanly.
+
+## What it does
+
+- After any `Write | Edit | MultiEdit`, the hook inspects the tool input.
+- If the written file matches Prettier's listed core extensions, it runs `prettier --write -- <file>` in place.
+- Any other extension exits silently.
+- Prettier discovers project configuration and ignore files through its normal rules.
+
+## Coexistence
+
+Supported:
+
+- `prettier-formatter` alone when Prettier should own every listed extension.
+- Prettier subset plugins alone when you want only selected languages.
+- Cross-tool subsets with disjoint extensions, such as `biome-json-formatter` + `prettier-yaml-formatter`.
+
+Unsupported:
+
+- `prettier-formatter` plus a Prettier subset, because both hooks can write the same file.
+- Two formatter subsets covering the same extension, such as `biome-json-formatter` + `prettier-json-formatter`.
+
+The hook does not detect these races; uninstall one overlapping formatter instead.
+
+## Files
+
+- `.claude-plugin/plugin.json` - plugin metadata.
+- `scripts/prettier-format-hook.sh` - POSIX sh hook script that parses stdin JSON and formats matching files.
+- `README.md` - usage notes and coexistence rules.
+
+Runtime configuration (the `hooks` block) belongs in the root `.claude-plugin/marketplace.json` entry.
+
+## Smoke testing
+
+Feed a hook event containing a matching `tool_input.file_path` into `scripts/prettier-format-hook.sh`.
+The file should be rewritten by Prettier when one runtime is installed.
+Out-of-scope files should produce no output and exit 0.

--- a/plugins/prettier-formatter/scripts/prettier-format-hook.sh
+++ b/plugins/prettier-formatter/scripts/prettier-format-hook.sh
@@ -29,6 +29,8 @@ print((d.get("tool_input") or {}).get("file_path") or "")
 }
 
 FILE=$(extract_file_path || true)
+[ -n "$FILE" ] || exit 0
+[ -f "$FILE" ] || exit 0
 
 case "$FILE" in
   *.js | *.mjs | *.cjs | *.jsx | *.ts | *.mts | *.cts | *.tsx | *.json | *.json5 | *.jsonc | *.css | *.scss | *.less | *.html | *.htm | *.md | *.markdown | *.mdx | *.yaml | *.yml) ;;

--- a/plugins/prettier-formatter/scripts/prettier-format-hook.sh
+++ b/plugins/prettier-formatter/scripts/prettier-format-hook.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+# PostToolUse hook: reformat Prettier-supported files after Write / Edit / MultiEdit.
+# Contract:
+#   - input: Claude Code hook event JSON on stdin.
+#   - output: never blocks the turn. Exits 0 in all paths.
+#     On out-of-scope files, silent. On missing runtimes, logs to stderr.
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+# Prefer python3 for robust JSON parsing; fall back to a sed/grep pipeline.
+extract_file_path() {
+  if try python3; then
+    python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((d.get("tool_input") or {}).get("file_path") or "")
+' 2>/dev/null
+  else
+    # Flatten newlines and grab the first file_path occurrence.
+    tr '\n' ' ' \
+      | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+      | head -1 \
+      | sed 's/.*"\([^"]*\)"$/\1/'
+  fi
+}
+
+FILE=$(extract_file_path || true)
+
+case "$FILE" in
+  *.js | *.mjs | *.cjs | *.jsx | *.ts | *.mts | *.cts | *.tsx | *.json | *.json5 | *.jsonc | *.css | *.scss | *.less | *.html | *.htm | *.md | *.markdown | *.mdx | *.yaml | *.yml) ;;
+  *) exit 0 ;;
+esac
+
+if try bunx; then exec bunx prettier --write -- "$FILE"; fi
+if try pnpm; then exec pnpm dlx prettier -- --write -- "$FILE"; fi
+if try npx;  then exec npx -y prettier --write -- "$FILE"; fi
+
+echo "prettier-formatter: skipped ($FILE) — install bun (https://bun.sh), pnpm (https://pnpm.io), or Node.js (ships npx) to enable." >&2
+exit 0

--- a/plugins/prettier-html-formatter/.claude-plugin/plugin.json
+++ b/plugins/prettier-html-formatter/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "prettier-html-formatter",
+  "version": "0.1.0",
+  "description": "Auto-format HTML and HTM files with Prettier after Claude writes them via a PostToolUse hook.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/prettier-html-formatter",
+  "license": "MIT"
+}

--- a/plugins/prettier-html-formatter/README.md
+++ b/plugins/prettier-html-formatter/README.md
@@ -1,0 +1,55 @@
+# prettier-html-formatter
+
+A PostToolUse hook that runs Prettier on HTML and HTM files Claude touches via `Write`, `Edit`, or `MultiEdit`.
+
+## Runtime
+
+JavaScript chain, in order:
+
+1. `bunx prettier --write -- <file>` - preferred
+2. `pnpm dlx prettier -- --write -- <file>` - fallback
+3. `npx -y prettier --write -- <file>` - fallback
+
+Install one:
+
+- https://bun.sh
+- https://pnpm.io
+- https://nodejs.org
+
+If none is present, the hook logs a one-line skip warning and exits cleanly.
+
+## What it does
+
+- After any `Write | Edit | MultiEdit`, the hook inspects the tool input.
+- If the written file ends in `.html` or `.htm`, it runs `prettier --write -- <file>` in place.
+- Any other extension exits silently.
+- Prettier discovers project configuration and ignore files through its normal rules.
+
+## Coexistence
+
+Supported:
+
+- `prettier-html-formatter` alone, or with other non-overlapping Prettier subsets.
+- Subset plugins alone when you want selected languages without installing `prettier-formatter`.
+- Cross-tool subsets with disjoint extensions, such as `biome-json-formatter` + `prettier-yaml-formatter`.
+
+Unsupported:
+
+- `prettier-formatter` plus `prettier-html-formatter`, because both hooks can write HTML files.
+- Two formatter subsets covering the same extension.
+
+The hook does not detect these races; uninstall one overlapping formatter instead.
+
+## Files
+
+- `.claude-plugin/plugin.json` - plugin metadata.
+- `scripts/prettier-html-format-hook.sh` - POSIX sh hook script that parses stdin JSON and formats matching files.
+- `README.md` - usage notes and coexistence rules.
+
+Runtime configuration (the `hooks` block) belongs in the root `.claude-plugin/marketplace.json` entry.
+
+## Smoke testing
+
+Feed a hook event containing a matching `tool_input.file_path` into `scripts/prettier-html-format-hook.sh`.
+The file should be rewritten by Prettier when one runtime is installed.
+Out-of-scope files should produce no output and exit 0.

--- a/plugins/prettier-html-formatter/scripts/prettier-html-format-hook.sh
+++ b/plugins/prettier-html-formatter/scripts/prettier-html-format-hook.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+# PostToolUse hook: reformat HTML files after Write / Edit / MultiEdit.
+# Contract:
+#   - input: Claude Code hook event JSON on stdin.
+#   - output: never blocks the turn. Exits 0 in all paths.
+#     On out-of-scope files, silent. On missing runtimes, logs to stderr.
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+# Prefer python3 for robust JSON parsing; fall back to a sed/grep pipeline.
+extract_file_path() {
+  if try python3; then
+    python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((d.get("tool_input") or {}).get("file_path") or "")
+' 2>/dev/null
+  else
+    # Flatten newlines and grab the first file_path occurrence.
+    tr '\n' ' ' \
+      | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+      | head -1 \
+      | sed 's/.*"\([^"]*\)"$/\1/'
+  fi
+}
+
+FILE=$(extract_file_path || true)
+
+case "$FILE" in
+  *.html | *.htm) ;;
+  *) exit 0 ;;
+esac
+
+if try bunx; then exec bunx prettier --write -- "$FILE"; fi
+if try pnpm; then exec pnpm dlx prettier -- --write -- "$FILE"; fi
+if try npx;  then exec npx -y prettier --write -- "$FILE"; fi
+
+echo "prettier-html-formatter: skipped ($FILE) — install bun (https://bun.sh), pnpm (https://pnpm.io), or Node.js (ships npx) to enable." >&2
+exit 0

--- a/plugins/prettier-html-formatter/scripts/prettier-html-format-hook.sh
+++ b/plugins/prettier-html-formatter/scripts/prettier-html-format-hook.sh
@@ -29,6 +29,8 @@ print((d.get("tool_input") or {}).get("file_path") or "")
 }
 
 FILE=$(extract_file_path || true)
+[ -n "$FILE" ] || exit 0
+[ -f "$FILE" ] || exit 0
 
 case "$FILE" in
   *.html | *.htm) ;;

--- a/plugins/prettier-js-formatter/.claude-plugin/plugin.json
+++ b/plugins/prettier-js-formatter/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "prettier-js-formatter",
+  "version": "0.1.0",
+  "description": "Auto-format JavaScript and TypeScript files with Prettier after Claude writes them via a PostToolUse hook.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/prettier-js-formatter",
+  "license": "MIT"
+}

--- a/plugins/prettier-js-formatter/README.md
+++ b/plugins/prettier-js-formatter/README.md
@@ -1,0 +1,55 @@
+# prettier-js-formatter
+
+A PostToolUse hook that runs Prettier on JavaScript and TypeScript files Claude touches via `Write`, `Edit`, or `MultiEdit`.
+
+## Runtime
+
+JavaScript chain, in order:
+
+1. `bunx prettier --write -- <file>` - preferred
+2. `pnpm dlx prettier -- --write -- <file>` - fallback
+3. `npx -y prettier --write -- <file>` - fallback
+
+Install one:
+
+- https://bun.sh
+- https://pnpm.io
+- https://nodejs.org
+
+If none is present, the hook logs a one-line skip warning and exits cleanly.
+
+## What it does
+
+- After any `Write | Edit | MultiEdit`, the hook inspects the tool input.
+- If the written file ends in `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.mts`, `.cts`, or `.tsx`, it runs `prettier --write -- <file>` in place.
+- Any other extension exits silently.
+- Prettier discovers project configuration and ignore files through its normal rules.
+
+## Coexistence
+
+Supported:
+
+- `prettier-js-formatter` alone, or with other non-overlapping Prettier subsets.
+- Subset plugins alone when you want selected languages without installing `prettier-formatter`.
+- Cross-tool subsets with disjoint extensions, such as `biome-json-formatter` + `prettier-yaml-formatter`.
+
+Unsupported:
+
+- `prettier-formatter` plus `prettier-js-formatter`, because both hooks can write JS and TS files.
+- Two formatter subsets covering the same extension, such as `biome-js-formatter` + `prettier-js-formatter`.
+
+The hook does not detect these races; uninstall one overlapping formatter instead.
+
+## Files
+
+- `.claude-plugin/plugin.json` - plugin metadata.
+- `scripts/prettier-js-format-hook.sh` - POSIX sh hook script that parses stdin JSON and formats matching files.
+- `README.md` - usage notes and coexistence rules.
+
+Runtime configuration (the `hooks` block) belongs in the root `.claude-plugin/marketplace.json` entry.
+
+## Smoke testing
+
+Feed a hook event containing a matching `tool_input.file_path` into `scripts/prettier-js-format-hook.sh`.
+The file should be rewritten by Prettier when one runtime is installed.
+Out-of-scope files should produce no output and exit 0.

--- a/plugins/prettier-js-formatter/scripts/prettier-js-format-hook.sh
+++ b/plugins/prettier-js-formatter/scripts/prettier-js-format-hook.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+# PostToolUse hook: reformat JS and TS files after Write / Edit / MultiEdit.
+# Contract:
+#   - input: Claude Code hook event JSON on stdin.
+#   - output: never blocks the turn. Exits 0 in all paths.
+#     On out-of-scope files, silent. On missing runtimes, logs to stderr.
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+# Prefer python3 for robust JSON parsing; fall back to a sed/grep pipeline.
+extract_file_path() {
+  if try python3; then
+    python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((d.get("tool_input") or {}).get("file_path") or "")
+' 2>/dev/null
+  else
+    # Flatten newlines and grab the first file_path occurrence.
+    tr '\n' ' ' \
+      | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+      | head -1 \
+      | sed 's/.*"\([^"]*\)"$/\1/'
+  fi
+}
+
+FILE=$(extract_file_path || true)
+
+case "$FILE" in
+  *.js | *.mjs | *.cjs | *.jsx | *.ts | *.mts | *.cts | *.tsx) ;;
+  *) exit 0 ;;
+esac
+
+if try bunx; then exec bunx prettier --write -- "$FILE"; fi
+if try pnpm; then exec pnpm dlx prettier -- --write -- "$FILE"; fi
+if try npx;  then exec npx -y prettier --write -- "$FILE"; fi
+
+echo "prettier-js-formatter: skipped ($FILE) — install bun (https://bun.sh), pnpm (https://pnpm.io), or Node.js (ships npx) to enable." >&2
+exit 0

--- a/plugins/prettier-js-formatter/scripts/prettier-js-format-hook.sh
+++ b/plugins/prettier-js-formatter/scripts/prettier-js-format-hook.sh
@@ -29,6 +29,8 @@ print((d.get("tool_input") or {}).get("file_path") or "")
 }
 
 FILE=$(extract_file_path || true)
+[ -n "$FILE" ] || exit 0
+[ -f "$FILE" ] || exit 0
 
 case "$FILE" in
   *.js | *.mjs | *.cjs | *.jsx | *.ts | *.mts | *.cts | *.tsx) ;;

--- a/plugins/prettier-json-formatter/.claude-plugin/plugin.json
+++ b/plugins/prettier-json-formatter/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "prettier-json-formatter",
+  "version": "0.1.0",
+  "description": "Auto-format JSON, JSON5, and JSONC files with Prettier after Claude writes them via a PostToolUse hook.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/prettier-json-formatter",
+  "license": "MIT"
+}

--- a/plugins/prettier-json-formatter/README.md
+++ b/plugins/prettier-json-formatter/README.md
@@ -1,0 +1,55 @@
+# prettier-json-formatter
+
+A PostToolUse hook that runs Prettier on JSON, JSON5, and JSONC files Claude touches via `Write`, `Edit`, or `MultiEdit`.
+
+## Runtime
+
+JavaScript chain, in order:
+
+1. `bunx prettier --write -- <file>` - preferred
+2. `pnpm dlx prettier -- --write -- <file>` - fallback
+3. `npx -y prettier --write -- <file>` - fallback
+
+Install one:
+
+- https://bun.sh
+- https://pnpm.io
+- https://nodejs.org
+
+If none is present, the hook logs a one-line skip warning and exits cleanly.
+
+## What it does
+
+- After any `Write | Edit | MultiEdit`, the hook inspects the tool input.
+- If the written file ends in `.json`, `.json5`, or `.jsonc`, it runs `prettier --write -- <file>` in place.
+- Any other extension exits silently.
+- Prettier discovers project configuration and ignore files through its normal rules.
+
+## Coexistence
+
+Supported:
+
+- `prettier-json-formatter` alone, or with other non-overlapping Prettier subsets.
+- Subset plugins alone when you want selected languages without installing `prettier-formatter`.
+- Cross-tool subsets with disjoint extensions, such as `biome-js-formatter` + `prettier-yaml-formatter`.
+
+Unsupported:
+
+- `prettier-formatter` plus `prettier-json-formatter`, because both hooks can write JSON-family files.
+- Two formatter subsets covering the same extension, such as `biome-json-formatter` + `prettier-json-formatter`.
+
+The hook does not detect these races; uninstall one overlapping formatter instead.
+
+## Files
+
+- `.claude-plugin/plugin.json` - plugin metadata.
+- `scripts/prettier-json-format-hook.sh` - POSIX sh hook script that parses stdin JSON and formats matching files.
+- `README.md` - usage notes and coexistence rules.
+
+Runtime configuration (the `hooks` block) belongs in the root `.claude-plugin/marketplace.json` entry.
+
+## Smoke testing
+
+Feed a hook event containing a matching `tool_input.file_path` into `scripts/prettier-json-format-hook.sh`.
+The file should be rewritten by Prettier when one runtime is installed.
+Out-of-scope files should produce no output and exit 0.

--- a/plugins/prettier-json-formatter/scripts/prettier-json-format-hook.sh
+++ b/plugins/prettier-json-formatter/scripts/prettier-json-format-hook.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+# PostToolUse hook: reformat JSON-family files after Write / Edit / MultiEdit.
+# Contract:
+#   - input: Claude Code hook event JSON on stdin.
+#   - output: never blocks the turn. Exits 0 in all paths.
+#     On out-of-scope files, silent. On missing runtimes, logs to stderr.
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+# Prefer python3 for robust JSON parsing; fall back to a sed/grep pipeline.
+extract_file_path() {
+  if try python3; then
+    python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((d.get("tool_input") or {}).get("file_path") or "")
+' 2>/dev/null
+  else
+    # Flatten newlines and grab the first file_path occurrence.
+    tr '\n' ' ' \
+      | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+      | head -1 \
+      | sed 's/.*"\([^"]*\)"$/\1/'
+  fi
+}
+
+FILE=$(extract_file_path || true)
+
+case "$FILE" in
+  *.json | *.json5 | *.jsonc) ;;
+  *) exit 0 ;;
+esac
+
+if try bunx; then exec bunx prettier --write -- "$FILE"; fi
+if try pnpm; then exec pnpm dlx prettier -- --write -- "$FILE"; fi
+if try npx;  then exec npx -y prettier --write -- "$FILE"; fi
+
+echo "prettier-json-formatter: skipped ($FILE) — install bun (https://bun.sh), pnpm (https://pnpm.io), or Node.js (ships npx) to enable." >&2
+exit 0

--- a/plugins/prettier-json-formatter/scripts/prettier-json-format-hook.sh
+++ b/plugins/prettier-json-formatter/scripts/prettier-json-format-hook.sh
@@ -29,6 +29,8 @@ print((d.get("tool_input") or {}).get("file_path") or "")
 }
 
 FILE=$(extract_file_path || true)
+[ -n "$FILE" ] || exit 0
+[ -f "$FILE" ] || exit 0
 
 case "$FILE" in
   *.json | *.json5 | *.jsonc) ;;

--- a/plugins/prettier-markdown-formatter/.claude-plugin/plugin.json
+++ b/plugins/prettier-markdown-formatter/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "prettier-markdown-formatter",
+  "version": "0.1.0",
+  "description": "Auto-format Markdown and MDX files with Prettier after Claude writes them via a PostToolUse hook.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/prettier-markdown-formatter",
+  "license": "MIT"
+}

--- a/plugins/prettier-markdown-formatter/README.md
+++ b/plugins/prettier-markdown-formatter/README.md
@@ -1,0 +1,55 @@
+# prettier-markdown-formatter
+
+A PostToolUse hook that runs Prettier on Markdown and MDX files Claude touches via `Write`, `Edit`, or `MultiEdit`.
+
+## Runtime
+
+JavaScript chain, in order:
+
+1. `bunx prettier --write -- <file>` - preferred
+2. `pnpm dlx prettier -- --write -- <file>` - fallback
+3. `npx -y prettier --write -- <file>` - fallback
+
+Install one:
+
+- https://bun.sh
+- https://pnpm.io
+- https://nodejs.org
+
+If none is present, the hook logs a one-line skip warning and exits cleanly.
+
+## What it does
+
+- After any `Write | Edit | MultiEdit`, the hook inspects the tool input.
+- If the written file ends in `.md`, `.markdown`, or `.mdx`, it runs `prettier --write -- <file>` in place.
+- Any other extension exits silently.
+- Prettier discovers project configuration and ignore files through its normal rules.
+
+## Coexistence
+
+Supported:
+
+- `prettier-markdown-formatter` alone, or with other non-overlapping Prettier subsets.
+- Subset plugins alone when you want selected languages without installing `prettier-formatter`.
+- Cross-tool subsets with disjoint extensions, such as `biome-json-formatter` + `prettier-yaml-formatter`.
+
+Unsupported:
+
+- `prettier-formatter` plus `prettier-markdown-formatter`, because both hooks can write Markdown files.
+- Two formatter subsets covering the same extension.
+
+The hook does not detect these races; uninstall one overlapping formatter instead.
+
+## Files
+
+- `.claude-plugin/plugin.json` - plugin metadata.
+- `scripts/prettier-markdown-format-hook.sh` - POSIX sh hook script that parses stdin JSON and formats matching files.
+- `README.md` - usage notes and coexistence rules.
+
+Runtime configuration (the `hooks` block) belongs in the root `.claude-plugin/marketplace.json` entry.
+
+## Smoke testing
+
+Feed a hook event containing a matching `tool_input.file_path` into `scripts/prettier-markdown-format-hook.sh`.
+The file should be rewritten by Prettier when one runtime is installed.
+Out-of-scope files should produce no output and exit 0.

--- a/plugins/prettier-markdown-formatter/scripts/prettier-markdown-format-hook.sh
+++ b/plugins/prettier-markdown-formatter/scripts/prettier-markdown-format-hook.sh
@@ -29,6 +29,8 @@ print((d.get("tool_input") or {}).get("file_path") or "")
 }
 
 FILE=$(extract_file_path || true)
+[ -n "$FILE" ] || exit 0
+[ -f "$FILE" ] || exit 0
 
 case "$FILE" in
   *.md | *.markdown | *.mdx) ;;

--- a/plugins/prettier-markdown-formatter/scripts/prettier-markdown-format-hook.sh
+++ b/plugins/prettier-markdown-formatter/scripts/prettier-markdown-format-hook.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+# PostToolUse hook: reformat Markdown and MDX files after Write / Edit / MultiEdit.
+# Contract:
+#   - input: Claude Code hook event JSON on stdin.
+#   - output: never blocks the turn. Exits 0 in all paths.
+#     On out-of-scope files, silent. On missing runtimes, logs to stderr.
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+# Prefer python3 for robust JSON parsing; fall back to a sed/grep pipeline.
+extract_file_path() {
+  if try python3; then
+    python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((d.get("tool_input") or {}).get("file_path") or "")
+' 2>/dev/null
+  else
+    # Flatten newlines and grab the first file_path occurrence.
+    tr '\n' ' ' \
+      | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+      | head -1 \
+      | sed 's/.*"\([^"]*\)"$/\1/'
+  fi
+}
+
+FILE=$(extract_file_path || true)
+
+case "$FILE" in
+  *.md | *.markdown | *.mdx) ;;
+  *) exit 0 ;;
+esac
+
+if try bunx; then exec bunx prettier --write -- "$FILE"; fi
+if try pnpm; then exec pnpm dlx prettier -- --write -- "$FILE"; fi
+if try npx;  then exec npx -y prettier --write -- "$FILE"; fi
+
+echo "prettier-markdown-formatter: skipped ($FILE) — install bun (https://bun.sh), pnpm (https://pnpm.io), or Node.js (ships npx) to enable." >&2
+exit 0

--- a/plugins/prettier-yaml-formatter/.claude-plugin/plugin.json
+++ b/plugins/prettier-yaml-formatter/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "prettier-yaml-formatter",
+  "version": "0.1.0",
+  "description": "Auto-format YAML files with Prettier after Claude writes them via a PostToolUse hook.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/prettier-yaml-formatter",
+  "license": "MIT"
+}

--- a/plugins/prettier-yaml-formatter/README.md
+++ b/plugins/prettier-yaml-formatter/README.md
@@ -1,0 +1,55 @@
+# prettier-yaml-formatter
+
+A PostToolUse hook that runs Prettier on YAML files Claude touches via `Write`, `Edit`, or `MultiEdit`.
+
+## Runtime
+
+JavaScript chain, in order:
+
+1. `bunx prettier --write -- <file>` - preferred
+2. `pnpm dlx prettier -- --write -- <file>` - fallback
+3. `npx -y prettier --write -- <file>` - fallback
+
+Install one:
+
+- https://bun.sh
+- https://pnpm.io
+- https://nodejs.org
+
+If none is present, the hook logs a one-line skip warning and exits cleanly.
+
+## What it does
+
+- After any `Write | Edit | MultiEdit`, the hook inspects the tool input.
+- If the written file ends in `.yaml` or `.yml`, it runs `prettier --write -- <file>` in place.
+- Any other extension exits silently.
+- Prettier discovers project configuration and ignore files through its normal rules.
+
+## Coexistence
+
+Supported:
+
+- `prettier-yaml-formatter` alone, or with other non-overlapping Prettier subsets.
+- Subset plugins alone when you want selected languages without installing `prettier-formatter`.
+- Cross-tool subsets with disjoint extensions, such as `biome-json-formatter` + `prettier-yaml-formatter`.
+
+Unsupported:
+
+- `prettier-formatter` plus `prettier-yaml-formatter`, because both hooks can write YAML files.
+- Two formatter subsets covering the same extension.
+
+The hook does not detect these races; uninstall one overlapping formatter instead.
+
+## Files
+
+- `.claude-plugin/plugin.json` - plugin metadata.
+- `scripts/prettier-yaml-format-hook.sh` - POSIX sh hook script that parses stdin JSON and formats matching files.
+- `README.md` - usage notes and coexistence rules.
+
+Runtime configuration (the `hooks` block) belongs in the root `.claude-plugin/marketplace.json` entry.
+
+## Smoke testing
+
+Feed a hook event containing a matching `tool_input.file_path` into `scripts/prettier-yaml-format-hook.sh`.
+The file should be rewritten by Prettier when one runtime is installed.
+Out-of-scope files should produce no output and exit 0.

--- a/plugins/prettier-yaml-formatter/scripts/prettier-yaml-format-hook.sh
+++ b/plugins/prettier-yaml-formatter/scripts/prettier-yaml-format-hook.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+# PostToolUse hook: reformat YAML files after Write / Edit / MultiEdit.
+# Contract:
+#   - input: Claude Code hook event JSON on stdin.
+#   - output: never blocks the turn. Exits 0 in all paths.
+#     On out-of-scope files, silent. On missing runtimes, logs to stderr.
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+# Prefer python3 for robust JSON parsing; fall back to a sed/grep pipeline.
+extract_file_path() {
+  if try python3; then
+    python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((d.get("tool_input") or {}).get("file_path") or "")
+' 2>/dev/null
+  else
+    # Flatten newlines and grab the first file_path occurrence.
+    tr '\n' ' ' \
+      | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+      | head -1 \
+      | sed 's/.*"\([^"]*\)"$/\1/'
+  fi
+}
+
+FILE=$(extract_file_path || true)
+
+case "$FILE" in
+  *.yaml | *.yml) ;;
+  *) exit 0 ;;
+esac
+
+if try bunx; then exec bunx prettier --write -- "$FILE"; fi
+if try pnpm; then exec pnpm dlx prettier -- --write -- "$FILE"; fi
+if try npx;  then exec npx -y prettier --write -- "$FILE"; fi
+
+echo "prettier-yaml-formatter: skipped ($FILE) — install bun (https://bun.sh), pnpm (https://pnpm.io), or Node.js (ships npx) to enable." >&2
+exit 0

--- a/plugins/prettier-yaml-formatter/scripts/prettier-yaml-format-hook.sh
+++ b/plugins/prettier-yaml-formatter/scripts/prettier-yaml-format-hook.sh
@@ -29,6 +29,8 @@ print((d.get("tool_input") or {}).get("file_path") or "")
 }
 
 FILE=$(extract_file_path || true)
+[ -n "$FILE" ] || exit 0
+[ -f "$FILE" ] || exit 0
 
 case "$FILE" in
   *.yaml | *.yml) ;;

--- a/plugins/tombi-lsp/.claude-plugin/plugin.json
+++ b/plugins/tombi-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "tombi-lsp",
+  "version": "0.1.0",
+  "description": "Tombi TOML language server, launched through uvx / pipx run without requiring a global install.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/tombi-lsp",
+  "license": "MIT"
+}

--- a/plugins/tombi-lsp/README.md
+++ b/plugins/tombi-lsp/README.md
@@ -1,0 +1,31 @@
+# tombi-lsp
+
+[Tombi](https://github.com/tombi-toml/tombi) language server, packaged for Claude Code.
+
+Tombi provides TOML diagnostics, completion, hover, and schema-aware editing without requiring a system Rust toolchain. It is distributed through PyPI, so this plugin launches it through the same Python runtime chain used by the Phase 1 Python tools.
+
+## Why Tombi
+
+Taplo is the TOML language server many users already know, but the npm `@taplo/cli` package does not ship the LSP. The Taplo language server is available from the native Rust binary built with LSP features, which is not a good fresh-exec dependency for this marketplace.
+
+Tombi gives Claude Code TOML coverage without adding new launcher infrastructure.
+
+## Runtime
+
+Python chain, in order:
+
+1. `uvx tombi`
+2. `pipx run tombi`
+
+At least one of `uvx` or `pipx` must be on `PATH`.
+
+## Notes
+
+- Claude Code starts the server with `lsp`; the marketplace entry supplies that through `args`.
+- Tombi is schema-aware for common TOML files, including `pyproject.toml` and `Cargo.toml`.
+- This plugin registers `.toml` files only.
+- There is no `python -m` fallback because Tombi is launched through its console script.
+
+## Manual Check
+
+Enable the plugin, open a `pyproject.toml` or `Cargo.toml`, and confirm Claude Code starts the `tombi` server. You should see TOML diagnostics and schema-backed completion for known sections.

--- a/plugins/tombi-lsp/scripts/launch-tombi-lsp.sh
+++ b/plugins/tombi-lsp/scripts/launch-tombi-lsp.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+if try uvx; then
+  exec uvx tombi "$@"
+fi
+if try pipx; then
+  exec pipx run tombi "$@"
+fi
+
+cat >&2 <<EOF
+error: no supported Python runtime found on PATH
+tried to launch: tombi $*
+install one of:
+  - https://docs.astral.sh/uv/
+  - https://pipx.pypa.io/
+EOF
+exit 127

--- a/plugins/vscode-css-lsp/.claude-plugin/plugin.json
+++ b/plugins/vscode-css-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "vscode-css-lsp",
+  "version": "0.1.0",
+  "description": "VS Code CSS language server, launched through bunx / pnpm dlx / npx without requiring a global install.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/vscode-css-lsp",
+  "license": "MIT"
+}

--- a/plugins/vscode-css-lsp/README.md
+++ b/plugins/vscode-css-lsp/README.md
@@ -1,0 +1,32 @@
+# vscode-css-lsp
+
+[`vscode-css-language-server`](https://github.com/hrsh7th/vscode-langservers-extracted) packaged for Claude Code with a no-global-install launcher.
+
+The server comes from `vscode-langservers-extracted`, the npm package that publishes the HTML, CSS, and JSON language servers extracted from VS Code. This plugin starts only the CSS binary.
+
+## Scope
+
+This plugin intentionally does not start the HTML or JSON servers. Install the matching plugin when those file types need language support.
+
+## Runtime
+
+JS/TS chain, in order:
+
+1. `bunx -p vscode-langservers-extracted vscode-css-language-server`
+2. `pnpm --package=vscode-langservers-extracted dlx vscode-css-language-server`
+3. `npx -y --package=vscode-langservers-extracted vscode-css-language-server`
+
+At least one of bun, pnpm, or node must be on `PATH`.
+
+## Notes
+
+- Claude Code starts the server with `--stdio`; the marketplace entry supplies that through `args`.
+- This plugin registers `.css`, `.scss`, and `.less` files.
+- Use this when you want stylesheet validation and completion without a project-local language server install.
+- The server is useful for design tokens, nested SCSS, Less variables, and plain CSS files.
+- The package also contains HTML and JSON language servers, but those are separate marketplace plugins so users can enable only the servers they want.
+- Sharing the npm package is intentional; local runtime caches handle reuse.
+
+## Manual Check
+
+Enable the plugin, open a CSS, SCSS, or Less file, and confirm Claude Code starts `vscode-css-language-server`. Completion, hover, document colors, and diagnostics should come from the VS Code CSS server.

--- a/plugins/vscode-css-lsp/scripts/launch-vscode-css-lsp.sh
+++ b/plugins/vscode-css-lsp/scripts/launch-vscode-css-lsp.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+if try bunx; then
+  exec bunx -p vscode-langservers-extracted vscode-css-language-server "$@"
+fi
+if try pnpm; then
+  exec pnpm --package=vscode-langservers-extracted dlx vscode-css-language-server -- "$@"
+fi
+if try npx; then
+  exec npx -y --package=vscode-langservers-extracted vscode-css-language-server -- "$@"
+fi
+
+cat >&2 <<EOF
+error: none of bunx / pnpm / npx found on PATH
+tried to launch: vscode-css-language-server (from vscode-langservers-extracted)
+install one of:
+  - https://bun.sh
+  - https://pnpm.io
+  - https://nodejs.org
+EOF
+exit 127

--- a/plugins/vscode-html-lsp/.claude-plugin/plugin.json
+++ b/plugins/vscode-html-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "vscode-html-lsp",
+  "version": "0.1.0",
+  "description": "VS Code HTML language server, launched through bunx / pnpm dlx / npx without requiring a global install.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/vscode-html-lsp",
+  "license": "MIT"
+}

--- a/plugins/vscode-html-lsp/README.md
+++ b/plugins/vscode-html-lsp/README.md
@@ -1,0 +1,32 @@
+# vscode-html-lsp
+
+[`vscode-html-language-server`](https://github.com/hrsh7th/vscode-langservers-extracted) packaged for Claude Code with a no-global-install launcher.
+
+The server comes from `vscode-langservers-extracted`, the npm package that publishes the HTML, CSS, and JSON language servers extracted from VS Code. This plugin starts only the HTML binary.
+
+## Scope
+
+This plugin intentionally does not start the CSS or JSON servers. Install the matching plugin when those file types need language support.
+
+## Runtime
+
+JS/TS chain, in order:
+
+1. `bunx -p vscode-langservers-extracted vscode-html-language-server`
+2. `pnpm --package=vscode-langservers-extracted dlx vscode-html-language-server`
+3. `npx -y --package=vscode-langservers-extracted vscode-html-language-server`
+
+At least one of bun, pnpm, or node must be on `PATH`.
+
+## Notes
+
+- Claude Code starts the server with `--stdio`; the marketplace entry supplies that through `args`.
+- This plugin registers `.html` and `.htm` files.
+- Use this when you want HTML-specific validation and editor features without installing the full VS Code extension stack.
+- The server is useful for plain HTML templates and generated static-site markup.
+- The package also contains CSS and JSON language servers, but those are separate marketplace plugins so users can enable only the servers they want.
+- Sharing the npm package is intentional; local runtime caches handle reuse.
+
+## Manual Check
+
+Enable the plugin, open an HTML file, and confirm Claude Code starts `vscode-html-language-server`. Completion, hover, document symbols, and diagnostics should come from the VS Code HTML server.

--- a/plugins/vscode-html-lsp/scripts/launch-vscode-html-lsp.sh
+++ b/plugins/vscode-html-lsp/scripts/launch-vscode-html-lsp.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+if try bunx; then
+  exec bunx -p vscode-langservers-extracted vscode-html-language-server "$@"
+fi
+if try pnpm; then
+  exec pnpm --package=vscode-langservers-extracted dlx vscode-html-language-server -- "$@"
+fi
+if try npx; then
+  exec npx -y --package=vscode-langservers-extracted vscode-html-language-server -- "$@"
+fi
+
+cat >&2 <<EOF
+error: none of bunx / pnpm / npx found on PATH
+tried to launch: vscode-html-language-server (from vscode-langservers-extracted)
+install one of:
+  - https://bun.sh
+  - https://pnpm.io
+  - https://nodejs.org
+EOF
+exit 127

--- a/plugins/vscode-json-lsp/.claude-plugin/plugin.json
+++ b/plugins/vscode-json-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "vscode-json-lsp",
+  "version": "0.1.0",
+  "description": "VS Code JSON language server, launched through bunx / pnpm dlx / npx without requiring a global install.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/vscode-json-lsp",
+  "license": "MIT"
+}

--- a/plugins/vscode-json-lsp/README.md
+++ b/plugins/vscode-json-lsp/README.md
@@ -1,0 +1,33 @@
+# vscode-json-lsp
+
+[`vscode-json-language-server`](https://github.com/hrsh7th/vscode-langservers-extracted) packaged for Claude Code with a no-global-install launcher.
+
+The server comes from `vscode-langservers-extracted`, the npm package that publishes the HTML, CSS, and JSON language servers extracted from VS Code. This plugin starts only the JSON binary.
+
+## Scope
+
+This plugin intentionally does not start the HTML or CSS servers. Install the matching plugin when those file types need language support.
+
+## Runtime
+
+JS/TS chain, in order:
+
+1. `bunx -p vscode-langservers-extracted vscode-json-language-server`
+2. `pnpm --package=vscode-langservers-extracted dlx vscode-json-language-server`
+3. `npx -y --package=vscode-langservers-extracted vscode-json-language-server`
+
+At least one of bun, pnpm, or node must be on `PATH`.
+
+## Notes
+
+- Claude Code starts the server with `--stdio`; the marketplace entry supplies that through `args`.
+- This plugin registers `.json` and `.jsonc` files.
+- Use this when schema-backed completion is more important than formatter or linter behavior.
+- The server is useful for `package.json`, `tsconfig.json`, and other common schema-backed JSON files.
+- It overlaps with `biome-lsp` on `.json` and `.jsonc`. If double diagnostics or duplicate completions are noisy, disable one of the two plugins for that project.
+- The package also contains HTML and CSS language servers, but those are separate marketplace plugins so users can enable only the servers they want.
+- Sharing the npm package is intentional; local runtime caches handle reuse.
+
+## Manual Check
+
+Enable the plugin, open a JSON or JSONC file, and confirm Claude Code starts `vscode-json-language-server`. Schema-backed completion and diagnostics should come from the VS Code JSON server.

--- a/plugins/vscode-json-lsp/scripts/launch-vscode-json-lsp.sh
+++ b/plugins/vscode-json-lsp/scripts/launch-vscode-json-lsp.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+if try bunx; then
+  exec bunx -p vscode-langservers-extracted vscode-json-language-server "$@"
+fi
+if try pnpm; then
+  exec pnpm --package=vscode-langservers-extracted dlx vscode-json-language-server -- "$@"
+fi
+if try npx; then
+  exec npx -y --package=vscode-langservers-extracted vscode-json-language-server -- "$@"
+fi
+
+cat >&2 <<EOF
+error: none of bunx / pnpm / npx found on PATH
+tried to launch: vscode-json-language-server (from vscode-langservers-extracted)
+install one of:
+  - https://bun.sh
+  - https://pnpm.io
+  - https://nodejs.org
+EOF
+exit 127

--- a/plugins/yaml-lsp/.claude-plugin/plugin.json
+++ b/plugins/yaml-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "yaml-lsp",
+  "version": "0.1.0",
+  "description": "YAML language server, launched via bunx / pnpm dlx / npx fallback without requiring a global install.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-code-plugins/tree/main/plugins/yaml-lsp",
+  "license": "MIT"
+}

--- a/plugins/yaml-lsp/README.md
+++ b/plugins/yaml-lsp/README.md
@@ -1,0 +1,36 @@
+# yaml-lsp
+
+[`yaml-language-server`](https://github.com/redhat-developer/yaml-language-server) packaged for Claude Code with a no-global-install launcher.
+
+## What it is
+
+`yaml-lsp` provides language-server features for YAML files, including diagnostics, completion, hover, validation, and schema-aware editing where the upstream server supports them.
+
+Use it for project configuration, CI workflows, deployment manifests, docker-compose files, and other YAML-heavy codebases.
+
+## How it runs
+
+JS/TS chain, in order:
+
+1. `bunx yaml-language-server`
+2. `pnpm dlx yaml-language-server`
+3. `npx -y yaml-language-server`
+
+At least one of bun / pnpm / node must be on `PATH`.
+
+Claude Code passes the language-server startup arguments via the marketplace entry. The wrapper only selects the first available runtime and execs `yaml-language-server` with those arguments.
+
+## Extensions
+
+This plugin registers:
+
+- `.yml`
+- `.yaml`
+
+Runtime configuration (the `lspServers` block) is declared at the marketplace level in the root `.claude-plugin/marketplace.json` entry for this plugin.
+
+## Notes
+
+- The upstream server includes a built-in schema catalog that covers common formats such as GitHub Actions, Kubernetes, and docker-compose.
+- Schema fetches happen over the network by default. In air-gapped or restricted environments, those remote lookups may fail or add latency.
+- If none of bunx, pnpm, or npx are available, the launcher exits 127 and prints install URLs for the supported runtimes.

--- a/plugins/yaml-lsp/scripts/launch-yaml-lsp.sh
+++ b/plugins/yaml-lsp/scripts/launch-yaml-lsp.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+if try bunx; then
+  exec bunx yaml-language-server "$@"
+fi
+if try pnpm; then
+  exec pnpm dlx yaml-language-server -- "$@"
+fi
+if try npx; then
+  exec npx -y yaml-language-server -- "$@"
+fi
+
+cat >&2 <<EOF
+error: none of bunx / pnpm / npx found on PATH
+tried to launch: yaml-language-server $*
+install one of:
+  - https://bun.sh
+  - https://pnpm.io
+  - https://nodejs.org
+EOF
+exit 127

--- a/templates/formatter-hook-plugin/.claude-plugin/plugin.json.example
+++ b/templates/formatter-hook-plugin/.claude-plugin/plugin.json.example
@@ -1,0 +1,8 @@
+{
+  "name": "EDIT_ME-formatter",
+  "version": "0.1.0",
+  "description": "EDIT ME — one-sentence description.",
+  "author": { "name": "EDIT_ME" },
+  "homepage": "https://github.com/EDIT_ME",
+  "license": "MIT"
+}

--- a/templates/formatter-hook-plugin/README.md
+++ b/templates/formatter-hook-plugin/README.md
@@ -1,0 +1,29 @@
+# Formatter Hook Plugin Template
+
+Reference skeleton for plugins that format a file after Claude writes it. Copy these files into a new `plugins/<name>/` directory and fill in the `EDIT_ME` placeholders.
+
+## Files
+
+- `.claude-plugin/plugin.json.example` -> `plugins/<name>/.claude-plugin/plugin.json`
+- `scripts/format-hook.sh.example` -> `plugins/<name>/scripts/<name>-format-hook.sh` (mark executable after copying)
+- `marketplace-entry.example.json` -> JSON fragment to paste into the root `.claude-plugin/marketplace.json` under `plugins`
+
+## When to use this template
+
+Use this for PostToolUse format-on-write plugins: tools that should run after `Write`, `Edit`, or `MultiEdit` and rewrite the touched file in place. It is the formatter-hook counterpart to `../js-ts-tool-plugin/` and `../python-tool-plugin/`.
+
+The template follows the hook contract described in:
+
+- `docs/superpowers/specs/2026-04-17-marketplace-design.md`
+- `docs/superpowers/specs/2026-04-17-marketplace-phase2-design.md`
+
+## What to customize
+
+- Plugin name, description, homepage, and author in `plugin.json`.
+- Extension whitelist in the `case "$FILE"` block. Each formatter should own only the extensions it can safely rewrite.
+- Tool command and runtime chain. The JS/TS chain is enabled by default; switch to the commented Python chain for PyPI-distributed formatters.
+- Warning prefix on the graceful-miss path so stderr clearly names the plugin.
+
+## Coexistence
+
+Keep formatter scopes disjoint. A monolith formatter and one of its same-tool subsets can both fire on the same file, and two subsets that claim the same extension can race. Document supported combinations in the plugin README.

--- a/templates/formatter-hook-plugin/marketplace-entry.example.json
+++ b/templates/formatter-hook-plugin/marketplace-entry.example.json
@@ -1,0 +1,22 @@
+{
+  "name": "EDIT_ME-formatter",
+  "source": "./plugins/EDIT_ME-formatter",
+  "description": "…",
+  "version": "0.1.0",
+  "category": "development",
+  "strict": false,
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/EDIT_ME-format-hook.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/templates/formatter-hook-plugin/scripts/format-hook.sh.example
+++ b/templates/formatter-hook-plugin/scripts/format-hook.sh.example
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+set -eu
+
+try() { command -v "$1" >/dev/null 2>&1; }
+
+# Prefer python3 for robust JSON parsing; fall back to a sed/grep pipeline.
+extract_file_path() {
+  if try python3; then
+    python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print((d.get("tool_input") or {}).get("file_path") or "")
+' 2>/dev/null
+  else
+    # Flatten newlines and grab the first file_path occurrence.
+    tr '\n' ' ' \
+      | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+      | head -1 \
+      | sed 's/.*"\([^"]*\)"$/\1/'
+  fi
+}
+
+FILE=$(extract_file_path || true)
+[ -f "$FILE" ] || exit 0
+
+case "$FILE" in
+  # EDIT ME: extensions this plugin owns
+  *.js | *.ts) ;;
+  *) exit 0 ;;
+esac
+
+# EDIT ME: pick JS/TS chain (bunx/pnpm/npx) or Python chain (uvx/pipx)
+if try bunx; then
+  exec bunx -p EDIT_ME_PACKAGE EDIT_ME_BINARY format --write -- "$FILE"
+fi
+if try pnpm; then
+  exec pnpm --package=EDIT_ME_PACKAGE dlx EDIT_ME_BINARY -- format --write -- "$FILE"
+fi
+if try npx; then
+  exec npx -y --package=EDIT_ME_PACKAGE EDIT_ME_BINARY format --write -- "$FILE"
+fi
+
+# if try uvx; then
+#   exec uvx EDIT_ME_TOOL format "$FILE"
+# fi
+# if try pipx; then
+#   exec pipx run EDIT_ME_TOOL format "$FILE"
+# fi
+
+# EDIT ME: <plugin-name> prefix
+echo "EDIT_ME-formatter: skipped ($FILE) - install a supported runtime to enable." >&2
+exit 0


### PR DESCRIPTION
## Summary
- Implements all 17 plugins from [docs/superpowers/specs/2026-04-17-marketplace-phase2-design.md](docs/superpowers/specs/2026-04-17-marketplace-phase2-design.md): 7 LSPs (bash, yaml, biome, tombi, vscode-html/css/json) + 10 formatters (biome monolith/js/json + prettier monolith/js/json/css/html/markdown/yaml).
- Adds `templates/formatter-hook-plugin/` as the fourth scaffold template.
- `.claude-plugin/marketplace.json` now carries 23 entries total (6 Phase 1 + 17 Phase 2), alphabetized.

## Design notes
- Every LSP launcher reuses the v2 chain contract (bunx → pnpm dlx → npx for JS/TS, uvx → pipx for Python) and returns 127 with an actionable stderr on miss.
- `vscode-*-lsp` use bespoke wrappers because `vscode-langservers-extracted` ships three binaries (follows the pyright `-p` / `--package=` precedent from Phase 1).
- Formatters use `tool_input.file_path` extraction cloned verbatim from `ruff-formatter` (python3-preferred, sed/grep fallback), graceful-miss semantics, per-plugin extension whitelists as physical scope boundaries.
- Formatter timeout set to 30s (matches Phase 1 ruff-formatter precedent; spec example showed 15s but 30s is safer for cold `bunx`).

## Test plan
- [ ] Run `jq . .claude-plugin/marketplace.json` — valid JSON, 23 entries.
- [ ] `sh -n` each plugin script — all 17 pass (verified pre-commit).
- [ ] Install `bash-lsp` + open a `.sh` file → server spawns, diagnostics appear.
- [ ] Install `biome-formatter` → writing a mis-indented `.ts` file gets reformatted.
- [ ] Install `prettier-yaml-formatter` + `biome-json-formatter` together → cross-tool, non-overlapping extensions, no race.
- [ ] Install `vscode-html-lsp` + `vscode-css-lsp` + `vscode-json-lsp` together → all three servers spawn; `bunx` caches the shared package once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)