### PR TITLE
feat: add deepwiki MCP plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -150,6 +150,20 @@
       }
     },
     {
+      "name": "deepwiki",
+      "source": "./plugins/deepwiki",
+      "description": "Devin DeepWiki MCP server for AI-grounded Q&A over any public GitHub repository's wiki. Remote HTTP transport, no auth.",
+      "version": "0.1.0",
+      "category": "development",
+      "strict": false,
+      "mcpServers": {
+        "deepwiki": {
+          "type": "http",
+          "url": "https://mcp.deepwiki.com/mcp"
+        }
+      }
+    },
+    {
       "name": "prettier-css-formatter",
       "source": "./plugins/prettier-css-formatter",
       "description": "Auto-format CSS / SCSS / Less with Prettier after Claude writes them. PostToolUse hook; bunx / pnpm dlx / npx fallback.",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Language servers, MCP servers, hooks, and workflow helpers &mdash; each tool boo
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin%20marketplace-6B4FBB)](https://docs.claude.com/en/docs/claude-code)
-[![Plugins](https://img.shields.io/badge/plugins-23-brightgreen)](#plugins)
+[![Plugins](https://img.shields.io/badge/plugins-24-brightgreen)](#plugins)
 [![Maintenance](https://img.shields.io/badge/status-active-success)](#)
 
 [Install](#install) &nbsp;·&nbsp; [Plugins](#plugins) &nbsp;·&nbsp; [Design](#design) &nbsp;·&nbsp; [Layout](#repository-layout) &nbsp;·&nbsp; [Contributing](#contributing)
@@ -50,6 +50,7 @@ Grouped by [plugin kind](https://docs.claude.com/en/docs/claude-code/plugins). A
 | Plugin | Purpose | Runtime chain |
 | --- | --- | --- |
 | [`context7`](plugins/context7) | Up-to-date library documentation lookup (Upstash Context7) | JS/TS |
+| [`deepwiki`](plugins/deepwiki) | AI-grounded Q&A over any public GitHub repo's wiki (Devin DeepWiki) | Remote HTTP |
 
 ### Hooks &mdash; Formatters
 

--- a/plugins/deepwiki/.claude-plugin/plugin.json
+++ b/plugins/deepwiki/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "deepwiki",
+  "version": "0.1.0",
+  "description": "Devin DeepWiki MCP server for AI-grounded Q&A over any public GitHub repository's wiki. Remote HTTP transport, no auth, no local runtime required.",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-plugins/tree/main/plugins/deepwiki",
+  "license": "MIT"
+}

--- a/plugins/deepwiki/README.md
+++ b/plugins/deepwiki/README.md
@@ -1,0 +1,21 @@
+# deepwiki
+
+Devin [DeepWiki](https://docs.devin.ai/work-with-devin/deepwiki-mcp) MCP server for AI-grounded Q&A over any public GitHub repository's wiki.
+
+Exposes three tools into the session:
+
+- `read_wiki_structure` — topic listings for a repo's generated wiki.
+- `read_wiki_contents` — fetch page contents.
+- `ask_question` — AI-powered, context-grounded answer about a repo.
+
+## Runtime
+
+None. DeepWiki is a remote streamable-HTTP MCP endpoint at `https://mcp.deepwiki.com/mcp`. No API key, no local process, no npm/pip.
+
+Private repo access is out of scope for this plugin — use Devin's own authenticated MCP server for that.
+
+## Files
+
+- `.claude-plugin/plugin.json` — plugin metadata.
+
+The `mcpServers` block is declared at the marketplace level in the root `.claude-plugin/marketplace.json` entry for this plugin.


### PR DESCRIPTION
## Summary

- Adds `deepwiki` plugin wrapping Devin's [DeepWiki MCP](https://docs.devin.ai/work-with-devin/deepwiki-mcp) server — AI-grounded Q&A over any public GitHub repo's generated wiki.
- Remote streamable-HTTP transport (`https://mcp.deepwiki.com/mcp`), no auth, no local runtime. Metadata-only plugin — no launcher script, no fallback chain needed (unlike `context7`).
- Exposes `read_wiki_structure`, `read_wiki_contents`, `ask_question` into the session.
- Registers the plugin in `.claude-plugin/marketplace.json` with `type: "http"` MCP config, and updates the root README (plugin count badge + MCP Servers table row).

## Test plan

- [ ] `python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"` — JSON validity (already run locally: OK)
- [ ] `/plugin install deepwiki@yousiki-claude-plugins` inside Claude Code
- [ ] Verify `read_wiki_structure`, `read_wiki_contents`, `ask_question` tools appear and work against a sample GitHub repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)