### PR TITLE
feat: add BrowserOS MCP plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -131,6 +131,19 @@
       }
     },
     {
+      "name": "browseros",
+      "source": "./plugins/browseros",
+      "description": "BrowserOS MCP server for driving the local BrowserOS agentic browser. Local streamable-HTTP transport; BrowserOS must be running with its MCP server enabled.",
+      "version": "0.1.0",
+      "category": "development",
+      "mcpServers": {
+        "browseros": {
+          "type": "http",
+          "url": "http://127.0.0.1:9000/mcp"
+        }
+      }
+    },
+    {
       "name": "context7",
       "source": "./plugins/context7",
       "description": "Upstash Context7 MCP server for up-to-date documentation lookup. bunx / pnpm dlx / npx fallback.",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Language servers, MCP servers, and formatter hooks &mdash; each tool is wrapped 
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin%20marketplace-6B4FBB)](https://docs.claude.com/en/docs/claude-code)
-[![Plugins](https://img.shields.io/badge/plugins-24-brightgreen)](#plugins)
+[![Plugins](https://img.shields.io/badge/plugins-25-brightgreen)](#plugins)
 [![Maintenance](https://img.shields.io/badge/status-active-success)](#)
 
 [Install](#install) &nbsp;·&nbsp; [Plugins](#plugins) &nbsp;·&nbsp; [Design](#design) &nbsp;·&nbsp; [Layout](#repository-layout) &nbsp;·&nbsp; [Contributing](#contributing)
@@ -49,6 +49,7 @@ Grouped by [plugin kind](https://docs.claude.com/en/docs/claude-code/plugins). A
 
 | Plugin | Purpose | Runtime chain |
 | --- | --- | --- |
+| [`browseros`](plugins/browseros) | Drive the local [BrowserOS](https://www.browseros.com/) agentic browser (53 browser tools + 40+ app integrations) | Local HTTP |
 | [`context7`](plugins/context7) | Up-to-date library documentation lookup (Upstash Context7) | JS/TS |
 | [`deepwiki`](plugins/deepwiki) | AI-grounded Q&A over any public GitHub repo's wiki (Devin DeepWiki) | Remote HTTP |
 

--- a/plugins/browseros/.claude-plugin/plugin.json
+++ b/plugins/browseros/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "browseros",
+  "version": "0.1.0",
+  "description": "BrowserOS MCP server for driving the local BrowserOS agentic browser from Claude Code. Local streamable-HTTP transport (127.0.0.1:9000 by default, set per your BrowserOS MCP settings).",
+  "author": { "name": "yousiki" },
+  "homepage": "https://github.com/yousiki/claude-plugins/tree/main/plugins/browseros",
+  "license": "MIT"
+}

--- a/plugins/browseros/README.md
+++ b/plugins/browseros/README.md
@@ -16,6 +16,10 @@ None. BrowserOS ships the MCP server inside the browser itself and exposes it on
 
 External-service auth (Gmail, Slack, …) is handled by BrowserOS itself via OAuth on first use; Claude Code never sees those credentials.
 
+## Security note
+
+MCP calls execute inside your **live BrowserOS session** — every site BrowserOS is already logged into (email, chat, code hosts, docs, Drive, Notion, …) is reachable through this plugin. Any Claude Code turn that uses the `browseros` MCP server can therefore read or mutate data in those services on your behalf. Install only if you're comfortable with that blast radius, and consider keeping sensitive sessions in a separate browser profile that BrowserOS doesn't share.
+
 ## Files
 
 - `.claude-plugin/plugin.json` — plugin metadata.

--- a/plugins/browseros/README.md
+++ b/plugins/browseros/README.md
@@ -1,0 +1,23 @@
+# browseros
+
+[BrowserOS](https://www.browseros.com/) MCP server — drive the local BrowserOS agentic browser from Claude Code.
+
+Exposes BrowserOS's built-in 53 browser-automation tools plus 40+ app integrations (Gmail, Slack, GitHub, Jira, Notion, Google Sheets, …) into the session over local HTTP. Everything runs on-device; no cloud hop for browser actions.
+
+## Runtime
+
+None. BrowserOS ships the MCP server inside the browser itself and exposes it on a local HTTP endpoint (e.g. `http://127.0.0.1:9000/mcp`). No API key, no launcher script, no npm/pip.
+
+## Prerequisites
+
+1. Install and launch the [BrowserOS browser](https://www.browseros.com/).
+2. In BrowserOS, open `chrome://browseros/mcp` (or **Settings → BrowserOS as MCP**) and enable the MCP server. That settings page shows the exact URL Claude Code should connect to — **treat it as the authoritative source**, not any URL in docs or this README.
+3. This plugin ships with `http://127.0.0.1:9000/mcp` (the URL current BrowserOS builds hand out). If your settings page shows a different port, edit the `url` for `browseros` in the root `.claude-plugin/marketplace.json` (marketplace-level `mcpServers` block) before installing.
+
+External-service auth (Gmail, Slack, …) is handled by BrowserOS itself via OAuth on first use; Claude Code never sees those credentials.
+
+## Files
+
+- `.claude-plugin/plugin.json` — plugin metadata.
+
+The `mcpServers` block is declared at the marketplace level in the root `.claude-plugin/marketplace.json` entry for this plugin.


### PR DESCRIPTION
## Summary
- Adds `browseros` plugin wrapping the BrowserOS built-in MCP server (local HTTP, no runtime, no launcher script)
- Registers a marketplace entry at `http://127.0.0.1:9000/mcp` with an explicit note that the `chrome://browseros/mcp` settings page is the authoritative source for the URL/port
- Updates the root README MCP table and bumps the plugin-count badge 24 → 25

## Test plan
- [ ] Launch BrowserOS and enable its MCP server at `chrome://browseros/mcp`
- [ ] From Claude Code run `/plugin marketplace add yousiki/claude-plugins` (or refresh) and `/plugin install browseros@yousiki-claude-plugins`
- [ ] Verify `mcp list` shows `browseros` and an authenticated tool call (e.g. open a tab) succeeds
- [ ] Confirm no `strict: false`/inline-components manifest warning surfaces in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)