### PR TITLE
fix: move MCP server declarations into each plugin's .mcp.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -135,39 +135,21 @@
       "source": "./plugins/browseros",
       "description": "BrowserOS MCP server for driving the local BrowserOS agentic browser. Local streamable-HTTP transport; BrowserOS must be running with its MCP server enabled.",
       "version": "0.1.0",
-      "category": "development",
-      "mcpServers": {
-        "browseros": {
-          "type": "http",
-          "url": "http://127.0.0.1:9000/mcp"
-        }
-      }
+      "category": "development"
     },
     {
       "name": "context7",
       "source": "./plugins/context7",
       "description": "Upstash Context7 MCP server for up-to-date documentation lookup. bunx / pnpm dlx / npx fallback.",
       "version": "0.1.0",
-      "category": "development",
-      "mcpServers": {
-        "context7": {
-          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-context7.sh"
-        }
-      }
+      "category": "development"
     },
     {
       "name": "deepwiki",
       "source": "./plugins/deepwiki",
       "description": "Devin DeepWiki MCP server for AI-grounded Q&A over any public GitHub repository's wiki. Remote HTTP transport, no auth.",
       "version": "0.1.0",
-      "category": "development",
-      "strict": false,
-      "mcpServers": {
-        "deepwiki": {
-          "type": "http",
-          "url": "https://mcp.deepwiki.com/mcp"
-        }
-      }
+      "category": "development"
     },
     {
       "name": "prettier-css-formatter",

--- a/plugins/browseros/.mcp.json
+++ b/plugins/browseros/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "browseros": {
+      "type": "http",
+      "url": "http://127.0.0.1:9000/mcp"
+    }
+  }
+}

--- a/plugins/browseros/README.md
+++ b/plugins/browseros/README.md
@@ -12,7 +12,7 @@ None. BrowserOS ships the MCP server inside the browser itself and exposes it on
 
 1. Install and launch the [BrowserOS browser](https://www.browseros.com/).
 2. In BrowserOS, open `chrome://browseros/mcp` (or **Settings → BrowserOS as MCP**) and enable the MCP server. That settings page shows the exact URL Claude Code should connect to — **treat it as the authoritative source**, not any URL in docs or this README.
-3. This plugin ships with `http://127.0.0.1:9000/mcp` (the URL current BrowserOS builds hand out). If your settings page shows a different port, edit the `url` for `browseros` in the root `.claude-plugin/marketplace.json` (marketplace-level `mcpServers` block) before installing.
+3. This plugin ships with `http://127.0.0.1:9000/mcp` (the URL current BrowserOS builds hand out). If your settings page shows a different port, edit the `url` in `plugins/browseros/.mcp.json` before installing.
 
 External-service auth (Gmail, Slack, …) is handled by BrowserOS itself via OAuth on first use; Claude Code never sees those credentials.
 
@@ -23,5 +23,4 @@ MCP calls execute inside your **live BrowserOS session** — every site BrowserO
 ## Files
 
 - `.claude-plugin/plugin.json` — plugin metadata.
-
-The `mcpServers` block is declared at the marketplace level in the root `.claude-plugin/marketplace.json` entry for this plugin.
+- `.mcp.json` — MCP server declaration (local streamable HTTP, `127.0.0.1:9000` by default).

--- a/plugins/context7/.mcp.json
+++ b/plugins/context7/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/launch-context7.sh"
+    }
+  }
+}

--- a/plugins/context7/README.md
+++ b/plugins/context7/README.md
@@ -17,9 +17,8 @@ At least one must be on `PATH`. If none is present, Claude Code will see the MCP
 ## Files
 
 - `.claude-plugin/plugin.json` — plugin metadata.
+- `.mcp.json` — MCP server declaration (stdio; points at the launcher below).
 - `scripts/launch-context7.sh` — runtime fallback wrapper, invoked over stdio.
-
-The `mcpServers` block is declared at the marketplace level in the root `.claude-plugin/marketplace.json` entry for this plugin.
 
 ## Smoke test
 

--- a/plugins/deepwiki/.mcp.json
+++ b/plugins/deepwiki/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "deepwiki": {
+      "type": "http",
+      "url": "https://mcp.deepwiki.com/mcp"
+    }
+  }
+}

--- a/plugins/deepwiki/README.md
+++ b/plugins/deepwiki/README.md
@@ -17,5 +17,4 @@ Private repo access is out of scope for this plugin — use Devin's own authenti
 ## Files
 
 - `.claude-plugin/plugin.json` — plugin metadata.
-
-The `mcpServers` block is declared at the marketplace level in the root `.claude-plugin/marketplace.json` entry for this plugin.
+- `.mcp.json` — MCP server declaration (remote streamable HTTP, `https://mcp.deepwiki.com/mcp`).


### PR DESCRIPTION
## Summary
- After install + `/reload-plugins` + fresh `claude` restart, Claude Code reported `0 plugin MCP servers` for all three MCP plugins (`context7`, `deepwiki`, `browseros`), regardless of transport (stdio vs remote-HTTP vs local-HTTP).
- Root cause: we were declaring `mcpServers` inline on the marketplace entry. The [official plugins reference](https://code.claude.com/docs/en/plugins-reference#mcp-servers) lists the default location as **`.mcp.json` at the plugin root** (or inline in `plugin.json`). Marketplace-level inline `mcpServers` are supposed to merge under `strict: true`, but in practice the runtime does not seem to register them the way it registers hook blocks.
- Fix: add `.mcp.json` to each of `plugins/browseros/`, `plugins/context7/`, `plugins/deepwiki/` and drop the `mcpServers` key from their marketplace entries. Plugin READMEs updated to point at the new file.

## Test plan
- [ ] `claude plugin validate .` passes (done locally — passes with only the unrelated pre-existing "no marketplace description" warning)
- [ ] `/plugin marketplace update yousiki-claude-plugins` in an existing session
- [ ] Fully quit and restart `claude`
- [ ] Confirm `/reload-plugins` reports a non-zero `plugin MCP servers` count (expect 1 per installed MCP plugin)
- [ ] Call a tool from each installed MCP plugin (e.g. `browseros` list tabs, `deepwiki` ask-question, `context7` resolve-library-id) and confirm the call routes to the server

## Follow-up (not in this PR)
- The LSP plugins also declare `lspServers` at the marketplace level. Same migration to `.lsp.json` at plugin root will likely be needed; deferring until LSP failure is actually observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)