### PR TITLE
fix(mcp): bump MCP plugins to 0.1.1 to force cache refresh

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -134,21 +134,21 @@
       "name": "browseros",
       "source": "./plugins/browseros",
       "description": "BrowserOS MCP server for driving the local BrowserOS agentic browser. Local streamable-HTTP transport; BrowserOS must be running with its MCP server enabled.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "development"
     },
     {
       "name": "context7",
       "source": "./plugins/context7",
       "description": "Upstash Context7 MCP server for up-to-date documentation lookup. bunx / pnpm dlx / npx fallback.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "development"
     },
     {
       "name": "deepwiki",
       "source": "./plugins/deepwiki",
       "description": "Devin DeepWiki MCP server for AI-grounded Q&A over any public GitHub repository's wiki. Remote HTTP transport, no auth.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "development"
     },
     {

--- a/plugins/browseros/.claude-plugin/plugin.json
+++ b/plugins/browseros/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "browseros",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "BrowserOS MCP server for driving the local BrowserOS agentic browser from Claude Code. Local streamable-HTTP transport (127.0.0.1:9000 by default, set per your BrowserOS MCP settings).",
   "author": { "name": "yousiki" },
   "homepage": "https://github.com/yousiki/claude-plugins/tree/main/plugins/browseros",

--- a/plugins/context7/.claude-plugin/plugin.json
+++ b/plugins/context7/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context7",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Upstash Context7 MCP server for up-to-date documentation lookup. Marketplace-adapted launcher uses bunx / pnpm dlx / npx fallback so no global install is required.",
   "author": { "name": "yousiki" },
   "homepage": "https://github.com/yousiki/claude-plugins/tree/main/plugins/context7",

--- a/plugins/deepwiki/.claude-plugin/plugin.json
+++ b/plugins/deepwiki/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deepwiki",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Devin DeepWiki MCP server for AI-grounded Q&A over any public GitHub repository's wiki. Remote HTTP transport, no auth, no local runtime required.",
   "author": { "name": "yousiki" },
   "homepage": "https://github.com/yousiki/claude-plugins/tree/main/plugins/deepwiki",


### PR DESCRIPTION
## Summary
- PR #10 moved MCP server declarations into each plugin's `.mcp.json` (correct per the plugins reference), but existing installs still reported `0 plugin MCP servers` after `/plugin marketplace update` + full `claude` restart.
- Root cause confirmed by inspecting `~/.claude/plugins/cache/yousiki-claude-plugins/<plugin>/0.1.0/` — the cached plugin dirs did **not** contain the new `.mcp.json` files. Claude Code only re-pulls a plugin from its source when the version number changes; we kept the version at `0.1.0`, so the cache was considered up to date and the new layout never reached users.
- This bumps `browseros`, `context7`, and `deepwiki` to `0.1.1` in both `plugin.json` and the marketplace entry so the next marketplace update pulls the corrected layout and registers the MCP servers.

## Test plan
- [ ] `/plugin marketplace update yousiki-claude-plugins`
- [ ] Fully quit and restart `claude`
- [ ] On restart, confirm plugin MCP server count is non-zero (expected ≥1 for any installed MCP plugin)
- [ ] `mcp__browseros__*` / `mcp__context7__*` / `mcp__deepwiki__*` tools appear in tool list and a basic call succeeds

## Notes
- The docs explicitly warn: *"If you change your plugin's code but don't bump the version in `plugin.json`, your plugin's existing users won't see your changes due to caching."* — that's exactly what bit us.
- Marketplace-entry version and plugin.json version are kept in sync to avoid the "plugin.json silently wins" trap documented in the same reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)